### PR TITLE
Add important information about alternative text

### DIFF
--- a/docs/guide/dev/a11y/README.md
+++ b/docs/guide/dev/a11y/README.md
@@ -134,6 +134,10 @@ Color blind users may have trouble accessing information that is conveyed with c
 
 The following features can be used by developers to ensure that content created with CKEditor is accessible.
 
+#### Support for the `alt` Attribute in Images
+
+All three of CKEditor 4's Image plugins offer support for the `alt` attribute. This is done through an "Alternative Text" prompt. If the prompt is left blank, the `alt` attribute will be `""`.
+
 #### Accessibility Checker
 
 The innovative {@link guide/dev/features/accessibility_checker/README Accessibility Checker} tool lets you inspect the accessibility level of content created in the editor and fix reported issues, often fully automatically. It is a **must-have addon** for government institutions and companies that are often required by law to ensure the content they produce meets accessibility standards. See the [working demo](https://sdk.ckeditor.com/samples/accessibilitychecker.html) and get the plugin [here](https://ckeditor.com/cke4/addon/a11ychecker).

--- a/docs/guide/dev/features/image/README.md
+++ b/docs/guide/dev/features/image/README.md
@@ -23,6 +23,7 @@ The default [Image](https://ckeditor.com/cke4/addon/image) plugin supports inser
 * It provides **image preview**.
 * It supports **adding links to images** through the dedicated Link tab directly in the Image Properties dialog.
 * It can be integrated with a **file manager** of your choice such as [CKFinder](https://ckeditor.com/ckeditor-4/ckfinder/) for image upload and storage support.
+* It allows you to set **alternative text** for low-vision or text-only users.
 
 <info-box info="">
     If you are looking for more modern image support with a clean UI and features such as image captions, drag and drop positioning, click and drag resizing, image alignment (including centering) with inline styles or CSS classes, custom image styles or cloud storage support with optimized images and responsive markup, try {@link guide/dev/features/image2/README Enhanced Image} and {@link guide/dev/features/easyimage/README Easy Image} plugins.

--- a/docs/guide/dev/features/image/README.md
+++ b/docs/guide/dev/features/image/README.md
@@ -23,7 +23,6 @@ The default [Image](https://ckeditor.com/cke4/addon/image) plugin supports inser
 * It provides **image preview**.
 * It supports **adding links to images** through the dedicated Link tab directly in the Image Properties dialog.
 * It can be integrated with a **file manager** of your choice such as [CKFinder](https://ckeditor.com/ckeditor-4/ckfinder/) for image upload and storage support.
-* It allows you to set **alternative text** for low-vision or text-only users.
 
 <info-box info="">
     If you are looking for more modern image support with a clean UI and features such as image captions, drag and drop positioning, click and drag resizing, image alignment (including centering) with inline styles or CSS classes, custom image styles or cloud storage support with optimized images and responsive markup, try {@link guide/dev/features/image2/README Enhanced Image} and {@link guide/dev/features/easyimage/README Easy Image} plugins.


### PR DESCRIPTION
I have an assignment that is due 2018-11-02 23:00:00GMT+10.5. I need to document that CKEditor 4's default image plugin supports adding alternative text. The only other person who will ever read my assignment is Dr. Scott Hollier, a web accessibility expert who himself is blind. For him, it is important that the phrase "alternative text" be in the documentation of CKEditor 4's default image plugin. And that is what I have done.