### PR TITLE
Fix for: "Report an Issue" link in docs should point to `ckeditor-dev` instead of `ckeditor-docs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "terser-webpack-plugin": "^1.2.1",
     "tslint": "^5.15.0",
     "typescript": "~3.1.1",
-    "umberto": "^1.0.0",
+    "umberto": "^1.1.3",
     "webpack": "^4.29.0",
     "zone.js": "^0.8.29"
   },

--- a/umberto.json
+++ b/umberto.json
@@ -3,8 +3,8 @@
 	"slug": "ckeditor4",
 	"path": "docs",
 	"github": {
-		"url": "https://github.com/ckeditor/ckeditor-dev",
-		"contributeUrl": "https://github.com/ckeditor/ckeditor-docs",
+		"url": "https://github.com/ckeditor/ckeditor4",
+		"contributeUrl": "https://github.com/ckeditor/ckeditor4-docs",
 		"issueUrl": "https://github.com/ckeditor/ckeditor4"
 	},
 	"docsearch": {

--- a/umberto.json
+++ b/umberto.json
@@ -3,8 +3,7 @@
 	"slug": "ckeditor4",
 	"path": "docs",
 	"github": {
-	"url": "https://github.com/ckeditor/ckeditor-dev",
-	"docsUrl": "https://github.com/ckeditor/ckeditor-docs"
+	"url": "https://github.com/ckeditor/ckeditor-dev"
 	},
 	"docsearch": {
 	"customRanking": [

--- a/umberto.json
+++ b/umberto.json
@@ -3,7 +3,9 @@
 	"slug": "ckeditor4",
 	"path": "docs",
 	"github": {
-	"url": "https://github.com/ckeditor/ckeditor-dev"
+		"url": "https://github.com/ckeditor/ckeditor-dev",
+		"contributeUrl": "https://github.com/ckeditor/ckeditor-docs",
+		"issueUrl": "https://github.com/ckeditor/ckeditor4"
 	},
 	"docsearch": {
 	"customRanking": [


### PR DESCRIPTION
I've removed `docsUrl` variable from `umberto.json`. Apparently when this variable is missing then `url` variable is used to create the _**Report an Issue**_ button.

Closes ckeditor/ckeditor4#2928