### PR TITLE
Update repo naming and links after changing from 'ckeditor-dev' to 'ckeditor4' etc

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
-All issues regarding CKEditor 4 Documentation should be reported in the `ckeditor-dev` repository - https://github.com/ckeditor/ckeditor-dev/issues/new/choose.
+All issues regarding CKEditor 4 Documentation should be reported in the `ckeditor4` repository - https://github.com/ckeditor/ckeditor4/issues/new/choose.
 
-Any issues reported here will be moved to the `ckeditor-dev` repository.
+Any issues reported here will be moved to the `ckeditor4` repository.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "repos/ckeditor-presets"]
 	path = repos/ckeditor-presets
-	url = https://github.com/ckeditor/ckeditor-presets.git
+	url = https://github.com/ckeditor/ckeditor4-presets.git
 [submodule "docs/sdk/examples/assets/ckeditor-docs-samples"]
 	path = docs/sdk/examples/assets/ckeditor-docs-samples
-	url = https://github.com/ckeditor/ckeditor-docs-samples.git
+	url = https://github.com/ckeditor/ckeditor4-docs-samples.git

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -16,4 +16,4 @@ default-expanded: CKEDITOR
 
 ## Contribute
 
-CKEditor is an Open Source project and your contribution is most welcome. Feel free to {@link guide/dev/issues_readme/README report bugs} or improve the code on [GitHub](https://github.com/ckeditor/ckeditor-dev). Since CKEditor is localized, you can also help [to translate it](https://www.transifex.com/ckeditor/ckeditor/). You do not need to be a programmer to contribute to the project!
+CKEditor is an Open Source project and your contribution is most welcome. Feel free to {@link guide/dev/issues_readme/README report bugs} or improve the code on [GitHub](https://github.com/ckeditor/ckeditor4). Since CKEditor is localized, you can also help [to translate it](https://www.transifex.com/ckeditor/ckeditor/). You do not need to be a programmer to contribute to the project!

--- a/docs/features/autocomplete/README.md
+++ b/docs/features/autocomplete/README.md
@@ -41,7 +41,7 @@ When you press <kbd>Enter</kbd>, <kbd>Tab</kbd> or any other customized {@linkap
 In this tutorial you will create a simple autocomplete implementation in the form of an `autotag` plugin.
 
 <info-box hint="">
-	You can also <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-autotag/autotag">download the entire `autotag` plugin folder</a> with the fully commented source code.
+	You can also <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-autotag/autotag">download the entire `autotag` plugin folder</a> with the fully commented source code.
 </info-box>
 
 Autocomplete feature uses two callbacks to customize matching and data feed:
@@ -145,7 +145,7 @@ config.itemTemplate = '<li data-id="{id}" class="issue-{type}">#{id}: {name}</li
 And create some custom {@linkapi CKEDITOR.plugins.autocomplete.configDefinition#outputTemplate output template}:
 
 ```javascript
-config.outputTemplate = '<a href="https://github.com/ckeditor/ckeditor-dev/issues/{id}">{name} (#{id})</a> ';
+config.outputTemplate = '<a href="https://github.com/ckeditor/ckeditor4/issues/{id}">{name} (#{id})</a> ';
 ```
 
 Note that when creating a custom item template you should use a `<li>` element with the `data-id="{id}"` attribute.
@@ -168,7 +168,7 @@ There is only one thing left to do &mdash; attach autocomplete to the editor alo
 new CKEDITOR.plugins.autocomplete( editor, config );
 ```
 
-You can review and download the complete solution in the [documentation code samples repository](https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-autotag/autotag).
+You can review and download the complete solution in the [documentation code samples repository](https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-autotag/autotag).
 
 {@img assets/img/autocomplete_03.png Custom autocomplete implementation with GitHub tickets.}
 

--- a/docs/guide/dev/a11y/README.md
+++ b/docs/guide/dev/a11y/README.md
@@ -31,7 +31,7 @@ In our accessibility testing we use the **latest Firefox** version with **latest
 
 This does not mean, however, that CKEditor has any major issues with other modern, standards-compliant browsers (including latest Internet Explorer versions) and alternative screen reader solutions like VoiceOver, NonVisual Desktop Access (NVDA) or ChromeVox. On the contrary: we assume that since we test in the most standards-compliant solution, other standards-compliant environments should also work correctly.
 
-In any case, if you encounter any accessibility-related issue while using CKEditor, please let us know by {@link guide/dev/issues_tracker/README creating an issue} on our [GitHub issues page](https://github.com/ckeditor/ckeditor-dev/issues). We treat all accessibility issues with utmost attention and will be happy to solve them and further improve CKEditor compliance with accessibility standards.
+In any case, if you encounter any accessibility-related issue while using CKEditor, please let us know by {@link guide/dev/issues_tracker/README creating an issue} on our [GitHub issues page](https://github.com/ckeditor/ckeditor4/issues). We treat all accessibility issues with utmost attention and will be happy to solve them and further improve CKEditor compliance with accessibility standards.
 
 ## Assisting Users with Special Needs
 

--- a/docs/guide/dev/browsers/README.md
+++ b/docs/guide/dev/browsers/README.md
@@ -55,7 +55,7 @@ CKEditor is also compatible with **Chrome for Android** (which is preinstalled o
 
 <info-box hint="">Prior to version 4.5 CKEditor was disabled in some versions of Chrome for Android and may be disabled in Internet Explorer Mobile for Windows Phone. You can, however, {@link guide/dev/deep_dive/unsupported_environments/README change CKEditor settings to accept any mobile environment} (at your own risk).</info-box>
 
-Full mobile support will be introduced in **CKEditor 5**. We aim to have perfect CKEditor support for most popular mobile platforms, so if you encountered an issue with an environment that is unsupported as of now, please report it on our [GitHub issues page](https://github.com/ckeditor/ckeditor-dev/issues).
+Full mobile support will be introduced in **CKEditor 5**. We aim to have perfect CKEditor support for most popular mobile platforms, so if you encountered an issue with an environment that is unsupported as of now, please report it on our [GitHub issues page](https://github.com/ckeditor/ckeditor4/issues).
 
 ## Unsupported Environments
 

--- a/docs/guide/dev/build/README.md
+++ b/docs/guide/dev/build/README.md
@@ -21,7 +21,7 @@ Instead, you must create a CKEditor "build" or "release version" (in contrast to
 
 ## The `dev/builder` Folder
 
-<info-box info="">The builder will only work on the source version of CKEditor cloned from the a Git repository (for example from the <a href="https://github.com/ckeditor/ckeditor-dev">official CKEditor development repository</a>). It will not work on the project downloaded as a <code>.zip</code> package.</info-box>
+<info-box info="">The builder will only work on the source version of CKEditor cloned from the a Git repository (for example from the <a href="https://github.com/ckeditor/ckeditor4">official CKEditor development repository</a>). It will not work on the project downloaded as a <code>.zip</code> package.</info-box>
 
 The source code of CKEditor contains a pre-configured environment that allows you to easily create editor builds.
 

--- a/docs/guide/dev/contributing/README.md
+++ b/docs/guide/dev/contributing/README.md
@@ -14,9 +14,9 @@ For licensing, see LICENSE.md.
 
 This section explains how you can contribute to CKEditor development. CKEditor is an Open Source product that is free for anyone to download, use, and customize. It has an amazing community around it that supports it in all possible ways. If you would like to contribute to its development, you can consider the following actions:
 
-1. {@link guide/dev/issues_readme/README Report bugs} or feature requests through the CKEditor [GitHub repository](https://github.com/ckeditor/ckeditor-dev/issues).
+1. {@link guide/dev/issues_readme/README Report bugs} or feature requests through the CKEditor [GitHub repository](https://github.com/ckeditor/ckeditor4/issues).
 
-2. Fork CKEditor at [GitHub](https://github.com/ckeditor/ckeditor-dev), fix bugs or propose new functionality by using {@link guide/dev/contributing_code/README pull requests}.
+2. Fork CKEditor at [GitHub](https://github.com/ckeditor/ckeditor4), fix bugs or propose new functionality by using {@link guide/dev/contributing_code/README pull requests}.
 
 3. Create your own plugins or skins and submit them to [CKEditor Add-Ons Repository](https://ckeditor.com/cke4/addons/plugins/all).
 

--- a/docs/guide/dev/contributing_code/README.md
+++ b/docs/guide/dev/contributing_code/README.md
@@ -12,7 +12,7 @@ For licensing, see LICENSE.md.
 
 # Contributing Code and Providing Patches to CKEditor
 
-To propose a bug fix or a new functionality you need to create a pull request in the [CKEditor GitHub repository](https://github.com/ckeditor/ckeditor-dev) (you can read more about [pull requests](https://help.github.com/articles/using-pull-requests/) and [how to create them](https://help.github.com/articles/creating-a-pull-request/) first).
+To propose a bug fix or a new functionality you need to create a pull request in the [CKEditor GitHub repository](https://github.com/ckeditor/ckeditor4) (you can read more about [pull requests](https://help.github.com/articles/using-pull-requests/) and [how to create them](https://help.github.com/articles/creating-a-pull-request/) first).
 
 ## Setting Up the Development Environment
 
@@ -26,7 +26,7 @@ To propose a bug fix or a new functionality you need to create a pull request in
 
 	* Install CKEditor's development dependencies (Grunt plugins, {@link guide/dev/tests/README Bender.js}, etc.)
 
-			cd ckeditor-dev
+			cd ckeditor4
 			npm install
 
 	* Set the {@link guide/dev/tests/README testing environment} up, because your changes in the editor code will need tests.
@@ -44,7 +44,7 @@ To propose a bug fix or a new functionality you need to create a pull request in
 
 ## Branches
 
-When the environment is set up and running you can start working on your patch. First, create a separate branch to group your changes. If there is an issue on our [GitHub issues page](https://github.com/ckeditor/ckeditor-dev/issues) use its number, otherwise {@link guide/dev/issues_tracker/README create a new issue} yourself and use its number or just pick any meaningful name:
+When the environment is set up and running you can start working on your patch. First, create a separate branch to group your changes. If there is an issue on our [GitHub issues page](https://github.com/ckeditor/ckeditor4/issues) use its number, otherwise {@link guide/dev/issues_tracker/README create a new issue} yourself and use its number or just pick any meaningful name:
 
 	git checkout -b t/12345
 
@@ -58,7 +58,7 @@ Every change which can be tested automatically should have at least one automate
  If you do not know how to write tests for your patch, you can make an {@link guide/dev/contributing_code/README#proposing-incomplete-patches incomplete pull request} and the core team will give you some hints or perhaps someone else from the community will step in.
 </info-box>
 
-Some types of features or bugs cannot be tested automatically. In such cases, create a manual test (see [this one](https://github.com/ckeditor/ckeditor-dev/tree/master/tests/tickets/12735) for instance).
+Some types of features or bugs cannot be tested automatically. In such cases, create a manual test (see [this one](https://github.com/ckeditor/ckeditor4/tree/master/tests/tickets/12735) for instance).
 
 <info-box hint="">
  To see manual tests in the Bender.js dashboard you need to change the filter from <code>is:unit</code> to <code>is:manual</code>.
@@ -70,7 +70,7 @@ Once your patch is ready, tested and committed, push your branch to your CKEdito
 
 	git push origin t/12345
 
-And [create a pull request](https://help.github.com/articles/creating-a-pull-request/) in the official [CKEditor repository](https://github.com/ckeditor/ckeditor-dev).
+And [create a pull request](https://help.github.com/articles/creating-a-pull-request/) in the official [CKEditor repository](https://github.com/ckeditor/ckeditor4).
 
 ## Review
 

--- a/docs/guide/dev/deep_dive/unsupported_environments/README.md
+++ b/docs/guide/dev/deep_dive/unsupported_environments/README.md
@@ -86,6 +86,6 @@ Although this is not a recommended approach, it is also possible to edit the {@l
 
 ## Help Us by Reporting Issues!
 
-Enabling CKEditor in unsupported environments is an experimental feature aimed at developers who are willing to help us bring official support to a wider range of devices and setups. We would thus appreciate if you {@link guide/dev/issues_tracker/README reported any issues} that you find on our [GitHub issues page](https://github.com/ckeditor/ckeditor-dev/issues). Do remember to describe the tested environment (operating system, browser, device) in as much detail as possible.
+Enabling CKEditor in unsupported environments is an experimental feature aimed at developers who are willing to help us bring official support to a wider range of devices and setups. We would thus appreciate if you {@link guide/dev/issues_tracker/README reported any issues} that you find on our [GitHub issues page](https://github.com/ckeditor/ckeditor4/issues). Do remember to describe the tested environment (operating system, browser, device) in as much detail as possible.
 
 If you are particularly interested in using CKEditor on mobile devices, you can check the results of our [recent study](http://dev.ckeditor.com/ticket/11712#comment:5) on the state of CKEditor support in iOS and Android.

--- a/docs/guide/dev/example_setups/README.md
+++ b/docs/guide/dev/example_setups/README.md
@@ -18,7 +18,7 @@ This article is a detailed explanation of sample editor configurations shown on 
 The Article Editor demo showcases an editor designed mainly for writing web text content like blog posts, articles etc.
 
 <info-box hint="">
-  Visit the <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/editors">ckeditor-docs-samples</a> GitHub repository to learn more about this configuration.
+  Visit the <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/editors">ckeditor4-docs-samples</a> GitHub repository to learn more about this configuration.
 </info-box>
 
 The Article Editor is based on the [Standard package](https://ckeditor.com/ckeditor-4/download/) with a few modifications:
@@ -39,7 +39,7 @@ The Article Editor is based on the [Standard package](https://ckeditor.com/ckedi
 The Document Editor demo showcases a more robust editor designed for creating documents which are usually later printed or exported to PDF files using tools like [wkhtmltopdf](https://github.com/wkhtmltopdf/wkhtmltopdf) or [PhantomJS](https://github.com/ariya/phantomjs) (note: PhantomJS 2.x currently has a [known zoom issue](https://github.com/ariya/phantomjs/issues/13997)).
 
 <info-box hint="">
-  Visit the <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/editors">ckeditor-docs-samples</a> GitHub repository to learn more about this configuration.
+  Visit the <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/editors">ckeditor4-docs-samples</a> GitHub repository to learn more about this configuration.
 </info-box>
 
 The Document Editor is based on the [Full package](https://ckeditor.com/ckeditor-4/download/) with a few modifications:
@@ -61,7 +61,7 @@ The Document Editor is based on the [Full package](https://ckeditor.com/ckeditor
 The Inline Editor demo showcases {@link guide/dev/inline/README inline editing} that allows you to edit any element on the page in-place.
 
 <info-box hint="">
-  Visit the <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/editors">ckeditor-docs-samples</a> GitHub repository to learn more about this configuration.
+  Visit the <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/editors">ckeditor4-docs-samples</a> GitHub repository to learn more about this configuration.
 </info-box>
 
 Inline editor provides a real WYSIWYG experience "out of the box" because unlike in {@link guide/dev/framed/README classic editor}, there is no `<iframe>` element surrounding the editing area. The CSS styles used for editor content are exactly the same as on the target page where the content is rendered.

--- a/docs/guide/dev/howtos/bugs_and_features/README.md
+++ b/docs/guide/dev/howtos/bugs_and_features/README.md
@@ -20,10 +20,10 @@ The {@link guide/dev/issues_readme/README Reporting Issues} article contains all
 
 ## How Do I Request New CKEditor Features?
 
-If you feel there is an interesting feature missing in CKEditor, go to our [GitHub issues page](https://github.com/ckeditor/ckeditor-dev/issues) and file a new issue.
+If you feel there is an interesting feature missing in CKEditor, go to our [GitHub issues page](https://github.com/ckeditor/ckeditor4/issues) and file a new issue.
 
 Please make sure you read the {@link guide/dev/issues_tracker/README Issues Tracker Site} article beforehand in order to make it easier for the developers to examine the issue. It is also recommended to start from a search at the [CKEditor Add-ons Repository](https://ckeditor.com/cke4/addons/plugins/all) to see whether the proposed functionality has not been implemented yet and offered as a plugin, either an official one or a community-provided add-on.
 
 When submitting a new ticket, feel free to attach your code suggestions or patches that can serve as a prototype for the requested feature.
 
-You are also most welcome to propose code changes with pull requests submitted to the official [ckeditor-dev](https://github.com/ckeditor/ckeditor-dev/pulls) repository. Do note that your code should meet some minimum requirements for code style or included tests, so please refer to the {@link guide/dev/contributing_code/README Contributing Code} article for more information.
+You are also most welcome to propose code changes with pull requests submitted to the official [ckeditor4](https://github.com/ckeditor/ckeditor4/pulls) repository. Do note that your code should meet some minimum requirements for code style or included tests, so please refer to the {@link guide/dev/contributing_code/README Contributing Code} article for more information.

--- a/docs/guide/dev/howtos/dialog_windows/README.md
+++ b/docs/guide/dev/howtos/dialog_windows/README.md
@@ -17,7 +17,7 @@ The following article contains tips about customizing the editor dialog windows.
 
 ## How Do I Change the Content of a CKEditor Dialog Window?
 
-CKEditor allows you to customize dialog windows without changing the original editor code. For an example on how to add or remove dialog window tabs and fields refer to the old "Using the JavaScript API to customize dialog windows" [sample](http://nightly.ckeditor.com/standard/samples/old/dialog/dialog.html) and its [source code](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/dialog/samples/dialog.html). Please note this sample is just an example which is not maintained anymore.
+CKEditor allows you to customize dialog windows without changing the original editor code. For an example on how to add or remove dialog window tabs and fields refer to the old "Using the JavaScript API to customize dialog windows" [sample](http://nightly.ckeditor.com/standard/samples/old/dialog/dialog.html) and its [source code](https://github.com/ckeditor/ckeditor4/blob/master/plugins/dialog/samples/dialog.html). Please note this sample is just an example which is not maintained anymore.
 
 ## How Do I Set a Default Value for a CKEditor Dialog Window Field?
 
@@ -66,7 +66,7 @@ After this customization the **Link** dialog window will contain the `www.exampl
 
 {@img assets/img/dialog_02.png Link dialog window with a default value for the URL field}
 
-For more examples on setting a default field value refer to the old "Using the JavaScript API to customize dialog windows" [sample](http://nightly.ckeditor.com/standard/samples/old/dialog/dialog.html) and its [source code](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/dialog/samples/dialog.html). Please note this sample is just an example which is not maintained anymore.
+For more examples on setting a default field value refer to the old "Using the JavaScript API to customize dialog windows" [sample](http://nightly.ckeditor.com/standard/samples/old/dialog/dialog.html) and its [source code](https://github.com/ckeditor/ckeditor4/blob/master/plugins/dialog/samples/dialog.html). Please note this sample is just an example which is not maintained anymore.
 
 <info-box hint=""> Since in some old browsers <code>default</code> is a reserved word in JavaScript, remember to always put it in quotes when used in your code (<code>'default'</code>).
 </info-box>

--- a/docs/guide/dev/howtos/support/README.md
+++ b/docs/guide/dev/howtos/support/README.md
@@ -40,9 +40,9 @@ CKEditor is and has always been an Open Source product. We are proud to be a par
 
 If you also want to support the development of CKEditor, it will be most welcome. Here are a couple of things that you can do:
 
-* {@link guide/dev/issues_readme/README Report bugs} or feature requests on our [GitHub issues page](https://github.com/ckeditor/ckeditor-dev/issues).
+* {@link guide/dev/issues_readme/README Report bugs} or feature requests on our [GitHub issues page](https://github.com/ckeditor/ckeditor4/issues).
 
-* {@link guide/dev/contributing_code/README Submit code patches} through pull requests in the [official CKEditor repository](https://github.com/ckeditor/ckeditor-dev).
+* {@link guide/dev/contributing_code/README Submit code patches} through pull requests in the [official CKEditor repository](https://github.com/ckeditor/ckeditor4).
 
 * Help [localize CKEditor](http://docs.cksource.com/CKEditor_3.x/Developers_Guide/Localization) into your native language and update existing localizations by joining us at the [CKEditor UI Translation Center](https://www.transifex.net/projects/p/ckeditor/).
 

--- a/docs/guide/dev/integration/file_browse_upload/dialog_add_file_browser/README.md
+++ b/docs/guide/dev/integration/file_browse_upload/dialog_add_file_browser/README.md
@@ -30,7 +30,7 @@ The [File Browser](https://ckeditor.com/cke4/addon/filebrowser) plugin is built-
 
 ### Adding the "Browse Server" Button
 
-To assign the File Browser plugin to an element inside a dialog window, set the `filebrowser` property. For example in the [Image plugin dialog window source](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/image/dialogs/image.js) you can find the following code:
+To assign the File Browser plugin to an element inside a dialog window, set the `filebrowser` property. For example in the [Image plugin dialog window source](https://github.com/ckeditor/ckeditor4/blob/master/plugins/image/dialogs/image.js) you can find the following code:
 
 ```js
 {
@@ -53,7 +53,7 @@ The `'info:txtUrl'` value instructs the plugin to update an element with the ID 
 
 ### Adding "Quick Upload" Support
 
-Again, to see how file uploads can be handled in a dialog window, the following working example from CKEditor will be used. In the [Image plugin dialog window source](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/image/dialogs/image.js) you can find the following definition of the `Upload` tab:
+Again, to see how file uploads can be handled in a dialog window, the following working example from CKEditor will be used. In the [Image plugin dialog window source](https://github.com/ckeditor/ckeditor4/blob/master/plugins/image/dialogs/image.js) you can find the following definition of the `Upload` tab:
 
 ```js
 {

--- a/docs/guide/dev/integration/vue/README.md
+++ b/docs/guide/dev/integration/vue/README.md
@@ -14,4 +14,4 @@ For licensing, see LICENSE.md.
 
 The CKEditor 4 Vue Integration is currently under development. Progress of our work can be tracked in the [CKEditor4-Vue repository](https://github.com/ckeditor/ckeditor4-vue).
 
-We are open for any valuable feedback. Don't hesitate to post any ideas or feature requests on the [Vue Integration issue page](https://github.com/ckeditor/ckeditor-dev/issues/2861).
+We are open for any valuable feedback. Don't hesitate to post any ideas or feature requests on the [Vue Integration issue page](https://github.com/ckeditor/ckeditor4/issues/2861).

--- a/docs/guide/dev/issues_readme/README.md
+++ b/docs/guide/dev/issues_readme/README.md
@@ -24,7 +24,7 @@ Most of the issues are reproducible on samples. If you have a different case tho
 
 ## Avoid Duplicates
 
-Before you file a new issue, make sure your issue has not been reported yet. Use the [search page](https://github.com/ckeditor/ckeditor-dev/issues) to check it.
+Before you file a new issue, make sure your issue has not been reported yet. Use the [search page](https://github.com/ckeditor/ckeditor4/issues) to check it.
 If the issue has already been reported, just add a 👍 (+1) reaction to it.
 
 CKEditor is in active development, so there is a chance that we have already fixed your issue in the current code base. You should thus also test it on the latest [Nightly Build](http://nightly.ckeditor.com).

--- a/docs/guide/dev/issues_tracker/README.md
+++ b/docs/guide/dev/issues_tracker/README.md
@@ -13,7 +13,7 @@ For licensing, see LICENSE.md.
 # Issues Tracker Site
 
 <info-box hint="">
-    CKEditor issues are handled through the <a href="https://github.com/ckeditor/ckeditor-dev/issues">GitHub issues page</a> since the CKEditor 4.7 release (May 25th, 2017). The <a href="https://dev.ckeditor.com">former tracking system</a> is still available in the read-only mode and all past issues are still available publicly.
+    CKEditor issues are handled through the <a href="https://github.com/ckeditor/ckeditor4/issues">GitHub issues page</a> since the CKEditor 4.7 release (May 25th, 2017). The <a href="https://dev.ckeditor.com">former tracking system</a> is still available in the read-only mode and all past issues are still available publicly.
 </info-box>
 
 The issues page is used daily by the CKEditor core team to organize and distribute the development workflow. It is also the right place to report issues.
@@ -46,8 +46,8 @@ Before clicking the following link, make sure you have read the instructions abo
 
 Only registered GitHub users may create issues. If you are not registered, take a minute to [create a GitHub account](https://github.com/join).
 
-Once you log in, you will be ready to [report a CKEditor issue](https://github.com/ckeditor/ckeditor-dev/issues/new/choose).
+Once you log in, you will be ready to [report a CKEditor issue](https://github.com/ckeditor/ckeditor4/issues/new/choose).
 
 ### Labels
 
-Each issue is categorised with labels. Refer to the [GitHub label list](https://github.com/ckeditor/ckeditor-dev/labels) for the label descriptions.
+Each issue is categorised with labels. Refer to the [GitHub label list](https://github.com/ckeditor/ckeditor4/labels) for the label descriptions.

--- a/docs/guide/dev/patching/README.md
+++ b/docs/guide/dev/patching/README.md
@@ -50,19 +50,19 @@ Check the size of the `ckeditor.js` file located in the `ckeditor` folder that i
 
 In order to apply patches to CKEditor and then build the release version, you need the source version. The source version of CKEditor is stored on GitHub.
 
-### ckeditor-dev vs ckeditor-presets
+### ckeditor4 vs ckeditor4-presets
 
-There are two repositories where CKEditor source files are kept: [`ckeditor-dev`](https://github.com/ckeditor/ckeditor-dev) and [`ckeditor-presets`](https://github.com/ckeditor/ckeditor-presets).
+There are two repositories where CKEditor source files are kept: [`ckeditor4`](https://github.com/ckeditor/ckeditor4) and [`ckeditor4-presets`](https://github.com/ckeditor/ckeditor4-presets).
 
-The `ckeditor-presets` repository is used by the CKEditor team to build the Basic/Standard/Full distributions. It uses `ckeditor-dev` as a dependency and scripts included there further automate the build process:
+The `ckeditor4-presets` repository is used by the CKEditor team to build the Basic/Standard/Full distributions. It uses `ckeditor4` as a dependency and scripts included there further automate the build process:
 
  - It has information about which plugins should be included in which preset.
  - It loads spell checker plugins (`scayt` and `wsc`) from separate repositories where they are developed, if they are to be included in a release.
  - It sets the proper configuration file in the release package depending on the created preset.
 
-Although `ckeditor-presets` saves time in the long term, to reduce the complexity of this documentation article we recommend cloning the `ckeditor-dev` repository.
+Although `ckeditor4-presets` saves time in the long term, to reduce the complexity of this documentation article we recommend cloning the `ckeditor4` repository.
 
-### Downloading ckeditor-dev
+### Downloading ckeditor4
 
 The following section descibes how to download the source version of CKEditor from its GitHub repository.
 
@@ -80,8 +80,8 @@ In this case the version of CKEditor is *4.4.4* and the revision is *1ba5105*.
 
 Use the following steps to download CKEditor with a command line tool.
 
-1. `git clone https://github.com/ckeditor/ckeditor-dev.git`
-2. `cd ckeditor-dev`
+1. `git clone https://github.com/ckeditor/ckeditor4.git`
+2. `cd ckeditor4`
 3. `git checkout <revision>`
 
 Where `<revision>` has to be set to exactly the same revision that you are using. For the example above that would be:
@@ -92,13 +92,13 @@ Where `<revision>` has to be set to exactly the same revision that you are using
 
 Use the following steps to download CKEditor directly from the browser.
 
-1. Open `https://github.com/ckeditor/ckeditor-dev/tree/<revision>` in your browser. For the example above the proper URL would be: [https://github.com/ckeditor/ckeditor-dev/tree/1ba5105](https://github.com/ckeditor/ckeditor-dev/tree/1ba5105).
+1. Open `https://github.com/ckeditor/ckeditor4/tree/<revision>` in your browser. For the example above the proper URL would be: [https://github.com/ckeditor/ckeditor4/tree/1ba5105](https://github.com/ckeditor/ckeditor4/tree/1ba5105).
 
 2. Press the "Download ZIP" button.
 
 	<img src="%BASE_PATH%/assets/img/patching_download_zip.png" width="814" height="448" alt="Downloading a selected revision from GitHub">
 
-3. Unzip the file and rename the top-level folder into `ckeditor-dev`.
+3. Unzip the file and rename the top-level folder into `ckeditor4`.
 
 ## Patching Process
 
@@ -106,7 +106,7 @@ CKEditor source code is stored in the Git repository. The development takes plac
 
 ### Select the Changes You Want to Port
 
-If you are reading this document, most probably you already know which feature you want to port. Whenever you find a change that you need to port it is recommended to find in which ticket on the [GitHub issues page](https://github.com/ckeditor/ckeditor-dev/issues) or a [former Development site](http://dev.ckeditor.com/) the change has been tracked.
+If you are reading this document, most probably you already know which feature you want to port. Whenever you find a change that you need to port it is recommended to find in which ticket on the [GitHub issues page](https://github.com/ckeditor/ckeditor4/issues) or a [former Development site](http://dev.ckeditor.com/) the change has been tracked.
 
 #### Example
 
@@ -114,7 +114,7 @@ Suppose you are interested in porting a patch for the following problem:
 
     Remove Format button did not remove the <cite> element in versions prior to 4.4.5.
 
-By looking into the [changelog](https://ckeditor.com/cke4/release-notes) you find a link to [ticket #12311](http://dev.ckeditor.com/ticket/12311). The ticket not only explains what the problem was and how to reproduce it, but at the end it also contains a link to a changeset where the code fix was introduced: [http://github.com/ckeditor/ckeditor-dev/commit/b373ace](http://github.com/ckeditor/ckeditor-dev/commit/b373ace)
+By looking into the [changelog](https://ckeditor.com/cke4/release-notes) you find a link to [ticket #12311](http://dev.ckeditor.com/ticket/12311). The ticket not only explains what the problem was and how to reproduce it, but at the end it also contains a link to a changeset where the code fix was introduced: [http://github.com/ckeditor/ckeditor4/commit/b373ace](http://github.com/ckeditor/ckeditor4/commit/b373ace)
 
 The hash of the changeset is `b373ace`.
 
@@ -124,8 +124,8 @@ The hash of the changeset is `b373ace`.
 
 If for any reason you cannot use Git, you have to apply the changes manually. It is highly unrecommended though. Be careful when changing the files manually.
 
-1. View the changes on GitHub using the link found in the ticket: [http://github.com/ckeditor/ckeditor-dev/commit/b373ace](http://github.com/ckeditor/ckeditor-dev/commit/b373ace)
-2. Search for relevant files in your `ckeditor-dev` folder. Open them in your editor.
+1. View the changes on GitHub using the link found in the ticket: [http://github.com/ckeditor/ckeditor4/commit/b373ace](http://github.com/ckeditor/ckeditor4/commit/b373ace)
+2. Search for relevant files in your `ckeditor4` folder. Open them in your editor.
 3. Add/modify/remove code as shown in the diff.
 
 Note that the **line numbers** displayed on GitHub and in your editor **might be different** due to different versions on which you work and to which the change was applied. In worst case it may turn out that the lines of code that have been changed do not even exist. In such case a {@link guide/dev/upgrade/README full upgrade} and testing will require less effort than continuing with patching.
@@ -136,7 +136,7 @@ As mentioned earlier, this is not a Git manual, so we will continue the instruct
 
 The hash of the changeset is `b373ace`, so open your command line tool and go through the steps below:
 
-1. `cd ckeditor-dev`
+1. `cd ckeditor4`
 2. `git show b373ace`
 
 	<img src="%BASE_PATH%/assets/img/patching_02.png" width="434" height="100" alt="Merge commit shown">
@@ -179,17 +179,17 @@ In order to be able to create the same build that you used so far, you should ta
 
 ### Add Missing Plugins to the `plugins` Folder
 
-It is possible that `ckeditor-dev/plugins` does not contain all plugins that your build had. Before building you need to verify `build-config.js` and check whether each plugin listed there exists in the `plugins` folder.
+It is possible that `ckeditor4/plugins` does not contain all plugins that your build had. Before building you need to verify `build-config.js` and check whether each plugin listed there exists in the `plugins` folder.
 
 #### Your Custom Plugins
 
-If you used a custom build of CKEditor with your own custom plugins, copy them to the `ckeditor-dev/plugins` folder.
+If you used a custom build of CKEditor with your own custom plugins, copy them to the `ckeditor4/plugins` folder.
 
 #### Spell Checker Plugins
 
-If the build that you used had spell checker plugins (`scayt` or `wsc`), then you need to copy them as well. Spell checker plugins must be downloaded with the proper revision. The revision of `scayt` and `wsc` plugin that was used with release versions of CKEditor can be checked in the `ckeditor-presets` repository
+If the build that you used had spell checker plugins (`scayt` or `wsc`), then you need to copy them as well. Spell checker plugins must be downloaded with the proper revision. The revision of `scayt` and `wsc` plugin that was used with release versions of CKEditor can be checked in the `ckeditor4-presets` repository
 
-1. Open [https://github.com/ckeditor/ckeditor-presets]( https://github.com/ckeditor/ckeditor-presets).
+1. Open [https://github.com/ckeditor/ckeditor4-presets]( https://github.com/ckeditor/ckeditor4-presets).
 
 2. Press the "branch:" selection list and then select the Tags tab.
 
@@ -235,15 +235,15 @@ Starting from version 4.4.2, the CKEditor project is using [Bender.js](https://g
 ### Testing CKEditor 4.4.4 (example)
 
 CKEditor 4.4.4 has been released on August 19th, 2014:<br>
-[https://github.com/ckeditor/ckeditor-dev/releases](https://github.com/ckeditor/ckeditor-dev/releases)
+[https://github.com/ckeditor/ckeditor4/releases](https://github.com/ckeditor/ckeditor4/releases)
 
 The latest version of Bender.js available on that day was 0.1.7:<br>
 [https://github.com/benderjs/benderjs/releases](https://github.com/benderjs/benderjs/releases)
 
-1. Clone the `ckeditor-dev` repository.
+1. Clone the `ckeditor4` repository.
 
 ``` sh
-git clone https://github.com/ckeditor/ckeditor-dev.git
+git clone https://github.com/ckeditor/ckeditor4.git
 ```
 2. Checkout the tag that indicates the version you want to work with.
 

--- a/docs/guide/dev/source/README.md
+++ b/docs/guide/dev/source/README.md
@@ -18,20 +18,20 @@ Working with the source code of CKEditor may be useful. These are some possible 
  * You are assembling the editor by yourself, by adding plugins and skins to it manually.
  * You want to understand the CKEditor API better by reading the code.
  * You want to fix an issue. (Yes, do it!)
- * You want to propose some new features or enhancements. (Likewise, we are [looking forward to them](https://github.com/ckeditor/ckeditor-dev/pulls)!)
+ * You want to propose some new features or enhancements. (Likewise, we are [looking forward to them](https://github.com/ckeditor/ckeditor4/pulls)!)
 
 
 ## Cloning from GitHub
 
-The CKEditor source code is available in the [ckeditor-dev](https://github.com/ckeditor/ckeditor-dev) Git repository hosted at GitHub.
+The CKEditor source code is available in the [ckeditor4](https://github.com/ckeditor/ckeditor4) Git repository hosted at GitHub.
 
 If you have Git installed in your system, use the following command line call to create your local copy:
 
 ``` sh
-git clone https://github.com/ckeditor/ckeditor-dev.git
+git clone https://github.com/ckeditor/ckeditor4.git
 ```
 
-This will download the full CKEditor development code into the `ckeditor-dev` folder.
+This will download the full CKEditor development code into the `ckeditor4` folder.
 
 ## Performance
 

--- a/docs/guide/dev/tests/README.md
+++ b/docs/guide/dev/tests/README.md
@@ -12,7 +12,7 @@ For licensing, see LICENSE.md.
 
 # CKEditor Testing Environment (Bender.js)
 
-An advanced project like CKEditor could not exist without a set of automated tests. CKEditor uses [Bender.js](https://github.com/benderjs/benderjs), our in-house JavaScript Test Framework, to cover code with tests. Not every feature can be tested automatically, but for those that can, we always implement tests. We encourage you to do the same when you create a pull request on [GitHub](https://github.com/ckeditor/ckeditor-dev) or fork the CKEditor repository in order to customize some editor behavior.
+An advanced project like CKEditor could not exist without a set of automated tests. CKEditor uses [Bender.js](https://github.com/benderjs/benderjs), our in-house JavaScript Test Framework, to cover code with tests. Not every feature can be tested automatically, but for those that can, we always implement tests. We encourage you to do the same when you create a pull request on [GitHub](https://github.com/ckeditor/ckeditor4) or fork the CKEditor repository in order to customize some editor behavior.
 
 ## Setting up Bender.js
 
@@ -44,16 +44,16 @@ you should see the following message:
 
 When Bender.js is installed you need to set up the CKEditor tests project.
 
-First of all, you need to {@link guide/dev/source/README clone the CKEditor development} repository hosted at [GitHub](https://github.com/ckeditor/ckeditor-dev):
+First of all, you need to {@link guide/dev/source/README clone the CKEditor development} repository hosted at [GitHub](https://github.com/ckeditor/ckeditor4):
 
 ``` sh
-> git clone https://github.com/ckeditor/ckeditor-dev.git
+> git clone https://github.com/ckeditor/ckeditor4.git
 ```
 
 Go to the main CKEditor directory (it should contain the `bender.js`, `package.json` files, among others, and the `tests/` directory):
 
 ```sh
-> cd ckeditor-dev
+> cd ckeditor4
 ```
 
 You will now need to install the Bender.js engine (`benderjs-cli` installed globally uses a local `benderjs` module) and all required modules, like the [Sinon.JS plugin for Bender.js](https://github.com/benderjs/benderjs-sinon). To do so use:
@@ -107,7 +107,7 @@ If you want, you can specify a port or a hostname where Bender.js runs:
 <info-box hint=""> Some tests require the browser to be in focus. This means that you can not use other applications when running them.
 </info-box>
 
-Please note that at the moment some random tests may fail in Internet Explorer. This is a known issue; however, if you run them again (when opened directly), they should pass. If a test fails a few times in a row, it is a sign that something went wrong. {@link guide/dev/issues_readme/README Report a CKEditor issue} on our [GitHub issues page](https://github.com/ckeditor/ckeditor-dev/issues) in such case. Remember to include a link to the failing test and information about the browser in which it fails.
+Please note that at the moment some random tests may fail in Internet Explorer. This is a known issue; however, if you run them again (when opened directly), they should pass. If a test fails a few times in a row, it is a sign that something went wrong. {@link guide/dev/issues_readme/README Report a CKEditor issue} on our [GitHub issues page](https://github.com/ckeditor/ckeditor4/issues) in such case. Remember to include a link to the failing test and information about the browser in which it fails.
 
 ## CKEditor Tests Structure
 
@@ -164,7 +164,7 @@ Please note that some CKEditor plugins are needed for reasons that might not be 
 * [Undo](https://ckeditor.com/cke4/addon/undo) (`undo`) &ndash; Needed to fire the {@linkapi CKEDITOR.editor#change change} event.
 * [Basic Styles](https://ckeditor.com/cke4/addon/basicstyles) (`basicstyles`) &ndash; Needed to preserve basic text formatting in your test HTML, otherwise {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filter} will remove all `<strong>`, `<em>`, `<u>` tags and so on.
 
-If the editor behaves differently when testing and during development, try to add all plugins you use during the development (you can find such list in the [`config.js`](https://github.com/ckeditor/ckeditor-dev/blob/master/config.js) file) and then remove redundant ones. Please note that adding all existing CKEditor plugins might not be a good solution since, for example, the [BBCode plugin](https://ckeditor.com/cke4/addon/bbcode) will strip HTML in your output.
+If the editor behaves differently when testing and during development, try to add all plugins you use during the development (you can find such list in the [`config.js`](https://github.com/ckeditor/ckeditor4/blob/master/config.js) file) and then remove redundant ones. Please note that adding all existing CKEditor plugins might not be a good solution since, for example, the [BBCode plugin](https://ckeditor.com/cke4/addon/bbcode) will strip HTML in your output.
 
 ### Tagging Tests
 
@@ -209,7 +209,7 @@ If there is a need to reference a Trac issue instead of the GitHub one, full URL
 
 CKEditor tests use the [YUI library](http://yuilibrary.com/) for assertions provided by the [Bender.js YUI plugin](https://github.com/benderjs/benderjs-yui/).
 
-The testing environment provides a bunch of [tools](https://github.com/ckeditor/ckeditor-dev/blob/master/tests/_benderjs/ckeditor/static/tools.js) useful when creating tests and the [Editor Bot](https://github.com/ckeditor/ckeditor-dev/blob/master/tests/_benderjs/ckeditor/static/bot.js) which helps you create and manage an editor instance.
+The testing environment provides a bunch of [tools](https://github.com/ckeditor/ckeditor4/blob/master/tests/_benderjs/ckeditor/static/tools.js) useful when creating tests and the [Editor Bot](https://github.com/ckeditor/ckeditor4/blob/master/tests/_benderjs/ckeditor/static/bot.js) which helps you create and manage an editor instance.
 
 ### Sample Test File
 
@@ -261,4 +261,4 @@ If you need, you can add the entire content of the `<html>` page element, for ex
 </body>
 ```
 
-To learn more about writing tests, check the [existing tests code](https://github.com/ckeditor/ckeditor-dev/tree/master/tests).
+To learn more about writing tests, check the [existing tests code](https://github.com/ckeditor/ckeditor4/tree/master/tests).

--- a/docs/guide/plugin_sdk/integration_with_acf/README.md
+++ b/docs/guide/plugin_sdk/integration_with_acf/README.md
@@ -40,7 +40,7 @@ This guide is based on the {@link guide/plugin_sdk/sample_2/README Simple Plugin
 tutorial and explains all code adjustments that are required to make it compatible with
 Advanced Content Filter.
 
-<info-box hint=""> You can <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-abbr-2">download the entire plugin folder</a> used in the Simple Plugin (Part 2) tutorial to follow the changes introduced in this guide.
+<info-box hint=""> You can <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-abbr-2">download the entire plugin folder</a> used in the Simple Plugin (Part 2) tutorial to follow the changes introduced in this guide.
 </info-box>
 
 ## Integrating with ACF to Introduce a New Content Type
@@ -252,7 +252,7 @@ pasting content and editing source code.
 
 Read more about {@linkapi CKEDITOR.feature#contentForms contentForms} in CKEditor JavaScript API.
 
-<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-abbr-acf">download the entire modified plugin folder</a> inluding the icon and the fully commented source code.
+<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-abbr-acf">download the entire modified plugin folder</a> inluding the icon and the fully commented source code.
 </info-box>
 
 ## Abbreviation Plugin Demo

--- a/docs/guide/plugin_sdk/sample/README.md
+++ b/docs/guide/plugin_sdk/sample/README.md
@@ -155,7 +155,7 @@ CKEDITOR.plugins.add( 'timestamp', {
 });
 ```
 
-<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-timestamp">download the entire plugin folder</a> including the icon and the fully commented source code.
+<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-timestamp">download the entire plugin folder</a> including the icon and the fully commented source code.
 </info-box>
 
 ## Working Example

--- a/docs/guide/plugin_sdk/sample_1/README.md
+++ b/docs/guide/plugin_sdk/sample_1/README.md
@@ -371,7 +371,7 @@ This is what we have in the `dialogs/abbr.js` file:
 		};
 	});
 
-<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-abbr-1">download the entire plugin folder</a> inluding the icon and the fully commented source code.
+<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-abbr-1">download the entire plugin folder</a> inluding the icon and the fully commented source code.
 </info-box>
 
 ## Working Example

--- a/docs/guide/plugin_sdk/sample_2/README.md
+++ b/docs/guide/plugin_sdk/sample_2/README.md
@@ -20,7 +20,7 @@ Instead of creating a new plugin, this time we are going to
 expand on the functionality of the **Abbreviation** plugin created in the
 {@link guide/plugin_sdk/sample_1/README previous installment} of the tutorial series.
 
-<info-box hint=""> We need to start where we previously left off. You can download the <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-abbr-1">entire plugin folder</a> including the icon and the fully commented source code.
+<info-box hint=""> We need to start where we previously left off. You can download the <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-abbr-1">entire plugin folder</a> including the icon and the fully commented source code.
 </info-box>
 
 If you have any doubts about the content of the plugin and its configuration, refer to the
@@ -467,7 +467,7 @@ This is what we have in the `dialogs/abbr.js` file:
 		};
 	});
 
-<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-abbr-2">download the entire plugin folder</a> inluding the icon and the fully commented source code.
+<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-abbr-2">download the entire plugin folder</a> inluding the icon and the fully commented source code.
 </info-box>
 
 ## Working Example

--- a/docs/guide/skin_sdk/compatibility_with_ckeditor_4_5/README.md
+++ b/docs/guide/skin_sdk/compatibility_with_ckeditor_4_5/README.md
@@ -23,7 +23,7 @@ It is highly recommended to make your skin compatible with CKEditor 4.5 because 
 
 You can add support for notifications to your skin in these three easy steps.
 
-1. Copy the [notification.css](https://github.com/ckeditor/ckeditor-dev/blob/master/skins/moono/notification.css) file from the [Moono skin](https://ckeditor.com/cke4/addon/moono) to your skin's directory.
+1. Copy the [notification.css](https://github.com/ckeditor/ckeditor4/blob/master/skins/moono/notification.css) file from the [Moono skin](https://ckeditor.com/cke4/addon/moono) to your skin's directory.
 
 2. In the `editor.css` file of your skin add the following line:
 
@@ -31,7 +31,7 @@ You can add support for notifications to your skin in these three easy steps.
 	@import url("notification.css");
 	```
 
-	See an [example](https://github.com/ckeditor/ckeditor-dev/blob/a513a923aeab1b388efbec2022af1f6d8403376a/skins/moono/editor.css#L47).
+	See an [example](https://github.com/ckeditor/ckeditor4/blob/a513a923aeab1b388efbec2022af1f6d8403376a/skins/moono/editor.css#L47).
 
 3. Modify the `notification.css` file to match your skin's styles.
 
@@ -110,7 +110,7 @@ You can add support for displaying that a dialog window is in a busy state by fo
 }
 ```
 
-2. Add the [spinner image](https://github.com/ckeditor/ckeditor-dev/blob/a513a923aeab1b388efbec2022af1f6d8403376a/skins/moono/images/spinner.gif) to the `images/` directory of your skin. It is used in Internet Explorer 8-9 which do not support CSS animations.
+2. Add the [spinner image](https://github.com/ckeditor/ckeditor4/blob/a513a923aeab1b388efbec2022af1f6d8403376a/skins/moono/images/spinner.gif) to the `images/` directory of your skin. It is used in Internet Explorer 8-9 which do not support CSS animations.
 
 3. Adjust the added styles to make the modifications match your skin styles.
 

--- a/docs/guide/widget_sdk/tutorial_1/README.md
+++ b/docs/guide/widget_sdk/tutorial_1/README.md
@@ -384,7 +384,7 @@ This should be added to your `contents.css` file:
 }
 ```
 
-<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-simplebox-1">download the entire plugin folder</a> including the icon, the fully commented source code, and a working sample. If you have any doubts about the installation process, see the <a href="https://github.com/ckeditor/ckeditor-docs-samples/blob/master/README.md">instructions</a>.
+<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-simplebox-1">download the entire plugin folder</a> including the icon, the fully commented source code, and a working sample. If you have any doubts about the installation process, see the <a href="https://github.com/ckeditor/ckeditor4-docs-samples/blob/master/README.md">instructions</a>.
 </info-box>
 
 ## Working Example

--- a/docs/guide/widget_sdk/tutorial_2/README.md
+++ b/docs/guide/widget_sdk/tutorial_2/README.md
@@ -24,7 +24,7 @@ The aim of this tutorial is to demonstrate **how to extend an existing CKEditor 
 
 Instead of creating a new plugin, this time we are going to expand on the functionality of the {@link guide/widget_sdk/tutorial_1/README Simple Box widget plugin created in the previous installment} of the widget tutorial series.
 
-<info-box hint=""> We need to start where we previously left off. You can <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-simplebox-1">download the entire plugin folder</a> including the icon, the fully commented source code, and a working sample. If you have any doubts about the installation process, see the <a href="https://github.com/ckeditor/ckeditor-docs-samples/blob/master/README.md">instructions</a>.
+<info-box hint=""> We need to start where we previously left off. You can <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-simplebox-1">download the entire plugin folder</a> including the icon, the fully commented source code, and a working sample. If you have any doubts about the installation process, see the <a href="https://github.com/ckeditor/ckeditor4-docs-samples/blob/master/README.md">instructions</a>.
 </info-box>
 
 Should you have any questions about the content of the existing plugin and its configuration, refer to the {@link guide/widget_sdk/tutorial_1/README Creating a Simple CKEditor Widget (Part 1)} tutorial.
@@ -446,7 +446,7 @@ The following are all styles needed by the widget that should be added to your `
 }
 ```
 
-<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-simplebox-2">download the entire plugin folder</a> including the icon, the fully commented source code, and a working sample. If you have any doubts about the installation process, see the <a href="https://github.com/ckeditor/ckeditor-docs-samples/blob/master/README.md">instructions</a>.
+<info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-simplebox-2">download the entire plugin folder</a> including the icon, the fully commented source code, and a working sample. If you have any doubts about the installation process, see the <a href="https://github.com/ckeditor/ckeditor4-docs-samples/blob/master/README.md">instructions</a>.
 </info-box>
 
 ## Working Example

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,4 +34,4 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 
 ## Contribute
 
-CKEditor is an Open Source project and your contribution is most welcome. Feel free to {@link guide/dev/issues_readme/README report bugs} or improve the code on [GitHub](https://github.com/ckeditor/ckeditor-dev). Since CKEditor is localized, you can also help [to translate it](https://www.transifex.com/ckeditor/ckeditor/). You do not need to be a programmer to contribute to the project!
+CKEditor is an Open Source project and your contribution is most welcome. Feel free to {@link guide/dev/issues_readme/README report bugs} or improve the code on [GitHub](https://github.com/ckeditor/ckeditor4). Since CKEditor is localized, you can also help [to translate it](https://www.transifex.com/ckeditor/ckeditor/). You do not need to be a programmer to contribute to the project!

--- a/docs/sdk/examples/abbr.html
+++ b/docs/sdk/examples/abbr.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Abbreviation Plugin</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -62,7 +62,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<div class="tip">
 				Abbreviation is a proof-of-concept plugin that can be
-				<a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-abbr-acf">downloaded</a>
+				<a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-abbr-acf">downloaded</a>
 				from the repository or created by following the step-by-step tutorial.
 			</div>
 

--- a/docs/sdk/examples/accessibility.html
+++ b/docs/sdk/examples/accessibility.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Accessibility and Keyboard Shortcuts</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/accessibilitychecker.html
+++ b/docs/sdk/examples/accessibilitychecker.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Accessibility Checker</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/acf.html
+++ b/docs/sdk/examples/acf.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>ACF &ndash; Automatic Mode</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/acfcustom.html
+++ b/docs/sdk/examples/acfcustom.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>ACF &ndash; Custom Mode</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/angular.html
+++ b/docs/sdk/examples/angular.html
@@ -14,7 +14,7 @@ For licensing, see license.html or https://sdk.ckeditor.com/license.html.
 	<title>Angular Integration</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/api.html
+++ b/docs/sdk/examples/api.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Using CKEditor API</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/assets/plugins/autotag/plugin.js
+++ b/docs/sdk/examples/assets/plugins/autotag/plugin.js
@@ -88,7 +88,7 @@ CKEDITOR.plugins.add( 'autotag', {
 
 			// Define the templates of the autocomplete suggestions dropdown and output text.
 			config.itemTemplate = '<li data-id={id}>#{id}: {name}</li>';
-			config.outputTemplate = '<a href="https://github.com/ckeditor/ckeditor-dev/issues/{id}">{name} (#{id})</a> ';
+			config.outputTemplate = '<a href="https://github.com/ckeditor/ckeditor4/issues/{id}">{name} (#{id})</a> ';
 
 			// Attach autocomplete to the editor.
 			new CKEDITOR.plugins.autocomplete( editor, config );

--- a/docs/sdk/examples/autocomplete.html
+++ b/docs/sdk/examples/autocomplete.html
@@ -14,7 +14,7 @@
 		<title>Autocomplete</title>
 		<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 		<link href="../template/theme/css/sdk.css" rel="stylesheet">
-		<script src="../../ckeditor-dev/ckeditor.js"></script>
+		<script src="../../ckeditor4/ckeditor.js"></script>
 		<script src="assets/picoModal-2.0.1.min.js"></script>
 		<script src="assets/contentloaded.js"></script>
 		<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/autogrow.html
+++ b/docs/sdk/examples/autogrow.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Editor Auto Grow</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/autotag.html
+++ b/docs/sdk/examples/autotag.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Autotag Plugin</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -89,7 +89,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<div class="tip">
 				Autotag is a proof-of-concept plugin that can be
-				<a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-autotag">downloaded</a>
+				<a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-autotag">downloaded</a>
 				from the repository or created by following the step-by-step tutorial.
 			</div>
 
@@ -100,7 +100,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</ul>
 
 			<script data-sample="1">
-				CKEDITOR.plugins.addExternal( 'autotag', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/ckeditor-docs-samples/tutorial-autotag/autotag/', 'plugin.js' );
+				CKEDITOR.plugins.addExternal( 'autotag', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/ckeditor4-docs-samples/tutorial-autotag/autotag/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
 					plugins: 'textmatch,toolbar,wysiwygarea,basicstyles,link,undo,autotag',

--- a/docs/sdk/examples/balloontoolbar.html
+++ b/docs/sdk/examples/balloontoolbar.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Balloon Toolbar</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/basicstyles.html
+++ b/docs/sdk/examples/basicstyles.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Basic Text Styles</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/bbcode.html
+++ b/docs/sdk/examples/bbcode.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->

--- a/docs/sdk/examples/classic.html
+++ b/docs/sdk/examples/classic.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Classic Editor</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/codesnippet.html
+++ b/docs/sdk/examples/codesnippet.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Code Snippets</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/colorbutton.html
+++ b/docs/sdk/examples/colorbutton.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Text and Background Color</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/copyformatting.html
+++ b/docs/sdk/examples/copyformatting.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Copying Text Formatting</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/devtools.html
+++ b/docs/sdk/examples/devtools.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Developer Tools</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/draganddrop.html
+++ b/docs/sdk/examples/draganddrop.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Drag and Drop Integration</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/easyimage.html
+++ b/docs/sdk/examples/easyimage.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Easy Image Plugin</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/enterkey.html
+++ b/docs/sdk/examples/enterkey.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Enter Key Configuration</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/fileupload.html
+++ b/docs/sdk/examples/fileupload.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>File Upload</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/fixedui.html
+++ b/docs/sdk/examples/fixedui.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Fixed User Interface</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/floatingui.html
+++ b/docs/sdk/examples/floatingui.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Floating User Interface</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/format.html
+++ b/docs/sdk/examples/format.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Text Formats</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/fullpage.html
+++ b/docs/sdk/examples/fullpage.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Editing Complete HTML Pages</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/htmlformatting.html
+++ b/docs/sdk/examples/htmlformatting.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>HTML Output Formatting</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/image.html
+++ b/docs/sdk/examples/image.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Default Image Plugin</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/image2.html
+++ b/docs/sdk/examples/image2.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Enhanced Image Plugin</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/inline.html
+++ b/docs/sdk/examples/inline.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Inline Editor</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/language.html
+++ b/docs/sdk/examples/language.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Multilingual Content</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/magicline.html
+++ b/docs/sdk/examples/magicline.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Magic Line</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/mathjax.html
+++ b/docs/sdk/examples/mathjax.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Mathematical Formulas</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/mathtype.html
+++ b/docs/sdk/examples/mathtype.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Mathematical and Chemical Formulas</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/mediaembed.html
+++ b/docs/sdk/examples/mediaembed.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Embedding Media Resources</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/mentions.html
+++ b/docs/sdk/examples/mentions.html
@@ -14,7 +14,7 @@
 		<title>Mentions, Tags and Emoji</title>
 		<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 		<link href="../template/theme/css/sdk.css" rel="stylesheet">
-		<script src="../../ckeditor-dev/ckeditor.js"></script>
+		<script src="../../ckeditor4/ckeditor.js"></script>
 		<script src="assets/picoModal-2.0.1.min.js"></script>
 		<script src="assets/contentloaded.js"></script>
 		<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/pastefromexcel.html
+++ b/docs/sdk/examples/pastefromexcel.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Paste from Excel</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/pastefromgoogledocs.html
+++ b/docs/sdk/examples/pastefromgoogledocs.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Paste from Google Docs</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/pastefromword.html
+++ b/docs/sdk/examples/pastefromword.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Paste from Word</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/placeholder.html
+++ b/docs/sdk/examples/placeholder.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Placeholders</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/react.html
+++ b/docs/sdk/examples/react.html
@@ -15,7 +15,7 @@ For licensing, see license.html or https://sdk.ckeditor.com/license.html.
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
 	<link rel="stylesheet" href="assets/react/samples.css">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/readonly.html
+++ b/docs/sdk/examples/readonly.html
@@ -18,7 +18,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>

--- a/docs/sdk/examples/removeformat.html
+++ b/docs/sdk/examples/removeformat.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Removing Text Formatting</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/resize.html
+++ b/docs/sdk/examples/resize.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Resizing Customization</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/saveajax.html
+++ b/docs/sdk/examples/saveajax.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Saving in Ajax Applications</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/savetextarea.html
+++ b/docs/sdk/examples/savetextarea.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Saving Textarea Data</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/sharedspace.html
+++ b/docs/sdk/examples/sharedspace.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Shared User Interface</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/simplebox.html
+++ b/docs/sdk/examples/simplebox.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Custom Widget</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -84,7 +84,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<div class="tip">
 				Simple Box is a proof-of-concept plugin that can be
-				<a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-simplebox-2">downloaded</a>
+				<a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-simplebox-2">downloaded</a>
 				from the repository or created by following the step-by-step tutorial.
 			</div>
 

--- a/docs/sdk/examples/size.html
+++ b/docs/sdk/examples/size.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Editor Size</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/sourcearea.html
+++ b/docs/sdk/examples/sourcearea.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Source Code Editing</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Spelling and Grammar Checking</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/standardpreset.html
+++ b/docs/sdk/examples/standardpreset.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Standard Preset</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/styles.html
+++ b/docs/sdk/examples/styles.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Styles and Stylesheet Parser</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/tabindex.html
+++ b/docs/sdk/examples/tabindex.html
@@ -13,7 +13,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>&quot;Tab&quot; Key Navigation</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/table.html
+++ b/docs/sdk/examples/table.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Tables with Column Resizing</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/timestamp.html
+++ b/docs/sdk/examples/timestamp.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Timestamp Plugin</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -52,7 +52,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<div class="tip">
 				Timestamp is a proof-of-concept plugin that can be
-				<a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-timestamp">downloaded</a>
+				<a href="https://github.com/ckeditor/ckeditor4-docs-samples/tree/master/tutorial-timestamp">downloaded</a>
 				from the repository or created by following the step-by-step tutorial.
 			</div>
 

--- a/docs/sdk/examples/toolbar.html
+++ b/docs/sdk/examples/toolbar.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Custom Toolbar</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/toolbarlocation.html
+++ b/docs/sdk/examples/toolbarlocation.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Toolbar Location</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/uicolor.html
+++ b/docs/sdk/examples/uicolor.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>UI Color</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>

--- a/docs/sdk/examples/uicolorpicker.html
+++ b/docs/sdk/examples/uicolorpicker.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>UI Color Picker</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/docs/sdk/examples/uilanguages.html
+++ b/docs/sdk/examples/uilanguages.html
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>UI Language</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<script src="../../ckeditor-dev/ckeditor.js"></script>
+	<script src="../../ckeditor4/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/uilanguages/languages.js"></script>
 	<script src="assets/contentloaded.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor4-docs",
-  "version": "4.13.1",
+  "version": "4.13.0",
   "description": "The official documentation of CKEditor 4. https://ckeditor.com/docs/",
   "dependencies": {
     "@angular-devkit/build-angular": "^0.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor-docs",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "description": "The official documentation of CKEditor 4. http://docs.ckeditor.com",
   "dependencies": {
     "@angular-devkit/build-angular": "^0.12.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ckeditor-docs",
+  "name": "ckeditor4-docs",
   "version": "4.13.1",
-  "description": "The official documentation of CKEditor 4. http://docs.ckeditor.com",
+  "description": "The official documentation of CKEditor 4. https://ckeditor.com/docs/",
   "dependencies": {
     "@angular-devkit/build-angular": "^0.12.3",
     "@angular/common": "^7.2.2",
@@ -49,7 +49,7 @@
   "author": "CKSource (http://cksource.com/)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ckeditor/ckeditor-docs"
+    "url": "https://github.com/ckeditor/ckeditor4-docs"
   },
   "license": "For licensing, see LICENSE.md.",
   "devDependencies": {


### PR DESCRIPTION
Part of the cleanup.

[Link](https://github.com/ckeditor/ckeditor4/issues/3518) to particular issue in CKEditor4 repo.

[Link](https://github.com/ckeditor/ckeditor4/issues/2793) to a broader discussion after rename.