### PR TITLE
Adjust default z-index for CKEditor to be consistent with Umberto

### DIFF
--- a/docs/sdk/examples/abbr.html
+++ b/docs/sdk/examples/abbr.html
@@ -78,6 +78,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'abbr', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/abbr/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'abbr'
 				} );
 			</script>

--- a/docs/sdk/examples/abbr.html
+++ b/docs/sdk/examples/abbr.html
@@ -78,7 +78,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'abbr', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/abbr/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'abbr'
 				} );
 			</script>

--- a/docs/sdk/examples/accessibility.html
+++ b/docs/sdk/examples/accessibility.html
@@ -120,6 +120,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 500
 				} );
 			</script>

--- a/docs/sdk/examples/accessibility.html
+++ b/docs/sdk/examples/accessibility.html
@@ -120,7 +120,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 500
 				} );
 			</script>

--- a/docs/sdk/examples/accessibilitychecker.html
+++ b/docs/sdk/examples/accessibilitychecker.html
@@ -149,6 +149,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				$.getJSON( 'assets/plugins/a11ychecker/libs/quail/tests.json' );
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'a11ychecker',
 					removePlugins: 'scayt,wsc',
 					height: 500,

--- a/docs/sdk/examples/accessibilitychecker.html
+++ b/docs/sdk/examples/accessibilitychecker.html
@@ -149,7 +149,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				$.getJSON( 'assets/plugins/a11ychecker/libs/quail/tests.json' );
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'a11ychecker',
 					removePlugins: 'scayt,wsc',
 					height: 500,

--- a/docs/sdk/examples/acf.html
+++ b/docs/sdk/examples/acf.html
@@ -110,7 +110,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<script data-sample="2">
 
 			CKEDITOR.replace( 'editor2', {
-				baseFloatZIndex: 10100,
+				baseFloatZIndex: 10005,
 				extraAllowedContent: 'u;span{color}'
 			} );
 
@@ -127,7 +127,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<textarea cols="80" id="editor3" name="editor3" rows="10" data-sample="3">&lt;p&gt;A sample &lt;u&gt;heavily formatted text&lt;/u&gt;, using &lt;strong&gt;&lt;span style="font-family: 'Comic Sans MS';font-size:16px"&gt;different fonts&lt;/span&gt;&lt;/strong&gt; and &lt;span style="font-size:18px;color:#00FF00;background-color: #FFFF00"&gt;text colors&lt;/span&gt;. &lt;/p&gt;</textarea>
 		<script data-sample="3">
 			CKEDITOR.replace( 'editor3', {
-				baseFloatZIndex: 10100,
+				baseFloatZIndex: 10005,
 				allowedContent: true
 			} );
 		</script>

--- a/docs/sdk/examples/acf.html
+++ b/docs/sdk/examples/acf.html
@@ -110,6 +110,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<script data-sample="2">
 
 			CKEDITOR.replace( 'editor2', {
+				baseFloatZIndex: 10100,
 				extraAllowedContent: 'u;span{color}'
 			} );
 
@@ -126,6 +127,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<textarea cols="80" id="editor3" name="editor3" rows="10" data-sample="3">&lt;p&gt;A sample &lt;u&gt;heavily formatted text&lt;/u&gt;, using &lt;strong&gt;&lt;span style="font-family: 'Comic Sans MS';font-size:16px"&gt;different fonts&lt;/span&gt;&lt;/strong&gt; and &lt;span style="font-size:18px;color:#00FF00;background-color: #FFFF00"&gt;text colors&lt;/span&gt;. &lt;/p&gt;</textarea>
 		<script data-sample="3">
 			CKEDITOR.replace( 'editor3', {
+				baseFloatZIndex: 10100,
 				allowedContent: true
 			} );
 		</script>

--- a/docs/sdk/examples/acfcustom.html
+++ b/docs/sdk/examples/acfcustom.html
@@ -133,6 +133,7 @@ span{!font-family};span{!color};span(!marker);
 			</p>
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					allowedContent:
 							'h1 h2 h3 p blockquote strong em;' +
 							'a[!href];' +

--- a/docs/sdk/examples/acfcustom.html
+++ b/docs/sdk/examples/acfcustom.html
@@ -133,7 +133,7 @@ span{!font-family};span{!color};span(!marker);
 			</p>
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					allowedContent:
 							'h1 h2 h3 p blockquote strong em;' +
 							'a[!href];' +

--- a/docs/sdk/examples/api.html
+++ b/docs/sdk/examples/api.html
@@ -151,7 +151,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				// Replace the <textarea id="editor1"> with a CKEditor instance.
 				// A reference to the editor object is returned by CKEDITOR.replace() allowing you to work with editor instances.
 				var editor = CKEDITOR.replace( 'editor1', {
-	baseFloatZIndex: 10100,
+	baseFloatZIndex: 10005,
 					height: 150
 				} );
 

--- a/docs/sdk/examples/api.html
+++ b/docs/sdk/examples/api.html
@@ -151,6 +151,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				// Replace the <textarea id="editor1"> with a CKEditor instance.
 				// A reference to the editor object is returned by CKEDITOR.replace() allowing you to work with editor instances.
 				var editor = CKEDITOR.replace( 'editor1', {
+	baseFloatZIndex: 10100,
 					height: 150
 				} );
 

--- a/docs/sdk/examples/autocomplete.html
+++ b/docs/sdk/examples/autocomplete.html
@@ -164,10 +164,11 @@
 							description: 'Technician which will handle this ticket.'
 						}
 					];
-			
+
 					CKEDITOR.addCss( 'span > .cke_placeholder { background-color: #ffeec2; }' );
-			
+
 					CKEDITOR.replace( 'editor1', {
+						baseFloatZIndex: 10100,
 						plugins: 'autocomplete,textmatch,toolbar,wysiwygarea,basicstyles,link,undo,placeholder',
 						toolbar: [
 							{ name: 'document', items: [ 'Undo', 'Redo' ] },
@@ -181,14 +182,14 @@
 										'<div><i>{description}</i></div>' +
 									'</li>',
 									outputTemplate = '[[{title}]]<span>&nbsp;</span>';
-		
+
 								var autocomplete = new CKEDITOR.plugins.autocomplete( evt.editor, {
 									textTestCallback: textTestCallback,
 									dataCallback: dataCallback,
 									itemTemplate: itemTemplate,
 									outputTemplate: outputTemplate
 								} );
-		
+
 								// Override default getHtmlToInsert to enable rich content output.
 								autocomplete.getHtmlToInsert = function( item ) {
 									return this.outputTemplate.output( item );
@@ -196,50 +197,50 @@
 							}
 						}
 					} );
-		
+
 					function textTestCallback( range ) {
 						if ( !range.collapsed ) {
 							return null;
 						}
-		
+
 						return CKEDITOR.plugins.textMatch.match( range, matchCallback );
 					}
-		
+
 					function matchCallback( text, offset ) {
 						var pattern = /\[{2}([A-z]|\])*$/,
 							match = text.slice( 0, offset )
 							.match( pattern );
-		
+
 						if ( !match ) {
 							return null;
 						}
-		
+
 						return {
 							start: match.index,
 							end: offset
 						};
 					}
-		
+
 					function dataCallback( matchInfo, callback ) {
 						var data = PLACEHOLDERS.filter( function( item ) {
 							var itemName = '[[' + item.name + ']]';
 							return itemName.indexOf( matchInfo.query.toLowerCase() ) == 0;
 						} );
-		
+
 						callback( data );
 					}
 				</script>
-			
+
 				<script>
 					var templates = CKEDITOR.document.findOne( '.templates' ),
 						list = new CKEDITOR.dom.element( 'ul' );
-		
+
 					CKEDITOR.tools.array.forEach( PLACEHOLDERS, function( placeholder ) {
 						var item = new CKEDITOR.dom.element( 'li' );
 						item.setHtml( '<code>' + placeholder.name + '</code>' );
 						list.append( item );
 					} );
-		
+
 					templates.append( list );
 				</script>
 			</section>

--- a/docs/sdk/examples/autocomplete.html
+++ b/docs/sdk/examples/autocomplete.html
@@ -168,7 +168,7 @@
 					CKEDITOR.addCss( 'span > .cke_placeholder { background-color: #ffeec2; }' );
 
 					CKEDITOR.replace( 'editor1', {
-						baseFloatZIndex: 10100,
+						baseFloatZIndex: 10005,
 						plugins: 'autocomplete,textmatch,toolbar,wysiwygarea,basicstyles,link,undo,placeholder',
 						toolbar: [
 							{ name: 'document', items: [ 'Undo', 'Redo' ] },

--- a/docs/sdk/examples/autogrow.html
+++ b/docs/sdk/examples/autogrow.html
@@ -72,7 +72,7 @@ config.autoGrow_bottomSpace = 50;
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'autogrow',
 					autoGrow_minHeight: 200,
 					autoGrow_maxHeight: 600,

--- a/docs/sdk/examples/autogrow.html
+++ b/docs/sdk/examples/autogrow.html
@@ -72,6 +72,7 @@ config.autoGrow_bottomSpace = 50;
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'autogrow',
 					autoGrow_minHeight: 200,
 					autoGrow_maxHeight: 600,

--- a/docs/sdk/examples/autotag.html
+++ b/docs/sdk/examples/autotag.html
@@ -103,6 +103,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'autotag', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/ckeditor-docs-samples/tutorial-autotag/autotag/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					plugins: 'textmatch,toolbar,wysiwygarea,basicstyles,link,undo,autotag',
 					toolbar: [
 						{ name: 'document', items: [ 'Undo', 'Redo' ] },

--- a/docs/sdk/examples/autotag.html
+++ b/docs/sdk/examples/autotag.html
@@ -103,7 +103,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'autotag', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/ckeditor-docs-samples/tutorial-autotag/autotag/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					plugins: 'textmatch,toolbar,wysiwygarea,basicstyles,link,undo,autotag',
 					toolbar: [
 						{ name: 'document', items: [ 'Undo', 'Redo' ] },

--- a/docs/sdk/examples/balloontoolbar.html
+++ b/docs/sdk/examples/balloontoolbar.html
@@ -77,6 +77,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'balloontoolbar,linkballoon,image2',
 					height: 240,
 

--- a/docs/sdk/examples/balloontoolbar.html
+++ b/docs/sdk/examples/balloontoolbar.html
@@ -77,7 +77,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'balloontoolbar,linkballoon,image2',
 					height: 240,
 

--- a/docs/sdk/examples/basicpreset.html
+++ b/docs/sdk/examples/basicpreset.html
@@ -63,6 +63,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
+				baseFloatZIndex: 10100,
 				height: 150
 			} );
 		</script>

--- a/docs/sdk/examples/basicpreset.html
+++ b/docs/sdk/examples/basicpreset.html
@@ -63,7 +63,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
-				baseFloatZIndex: 10100,
+				baseFloatZIndex: 10005,
 				height: 150
 			} );
 		</script>

--- a/docs/sdk/examples/basicstyles.html
+++ b/docs/sdk/examples/basicstyles.html
@@ -156,7 +156,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 200,
 					// By default, some basic text styles buttons are removed in the Standard preset.
 					// The code below resets the default config.removeButtons setting.
@@ -166,7 +166,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 200,
 					// By default, some basic text styles buttons are removed in the Standard preset.
 					// The code below resets the default config.removeButtons setting.

--- a/docs/sdk/examples/basicstyles.html
+++ b/docs/sdk/examples/basicstyles.html
@@ -156,6 +156,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 200,
 					// By default, some basic text styles buttons are removed in the Standard preset.
 					// The code below resets the default config.removeButtons setting.
@@ -165,6 +166,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					height: 200,
 					// By default, some basic text styles buttons are removed in the Standard preset.
 					// The code below resets the default config.removeButtons setting.

--- a/docs/sdk/examples/bbcode.html
+++ b/docs/sdk/examples/bbcode.html
@@ -68,7 +68,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				// instance, using the "bbcode" plugin, customizing some of the
 				// editor configuration options to fit BBCode environment.
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 280,
 					// Add plugins providing functionality popular in BBCode environment.
 					extraPlugins: 'bbcode,smiley,font,colorbutton,justify',

--- a/docs/sdk/examples/bbcode.html
+++ b/docs/sdk/examples/bbcode.html
@@ -68,6 +68,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				// instance, using the "bbcode" plugin, customizing some of the
 				// editor configuration options to fit BBCode environment.
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 280,
 					// Add plugins providing functionality popular in BBCode environment.
 					extraPlugins: 'bbcode,smiley,font,colorbutton,justify',

--- a/docs/sdk/examples/classic.html
+++ b/docs/sdk/examples/classic.html
@@ -100,12 +100,14 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</p>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 260,
 					width: 700,
 				} );
 			</script>
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					height: 260,
 					/* Default CKEditor styles are included as well to avoid copying default styles. */
 					contentsCss: [

--- a/docs/sdk/examples/classic.html
+++ b/docs/sdk/examples/classic.html
@@ -100,14 +100,14 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</p>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 260,
 					width: 700,
 				} );
 			</script>
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 260,
 					/* Default CKEditor styles are included as well to avoid copying default styles. */
 					contentsCss: [

--- a/docs/sdk/examples/colorbutton.html
+++ b/docs/sdk/examples/colorbutton.html
@@ -124,6 +124,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					extraPlugins: 'colorbutton,colordialog'
 				} );
@@ -131,6 +132,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					extraPlugins: 'colorbutton',
 					colorButton_colors: 'CF5D4E,454545,FFF,CCC,DDD,CCEAEE,66AB16',

--- a/docs/sdk/examples/colorbutton.html
+++ b/docs/sdk/examples/colorbutton.html
@@ -124,7 +124,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					extraPlugins: 'colorbutton,colordialog'
 				} );
@@ -132,7 +132,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					extraPlugins: 'colorbutton',
 					colorButton_colors: 'CF5D4E,454545,FFF,CCC,DDD,CCEAEE,66AB16',

--- a/docs/sdk/examples/copyformatting.html
+++ b/docs/sdk/examples/copyformatting.html
@@ -242,7 +242,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 255,
 					// Add Copy Formatting and Color Button (Text and Background Color features) plugins.
 					// Color Button is only added just to show that text and background colors can be copied, too.
@@ -252,7 +252,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 450,
 					// Add Copy Formatting and Color Button (Text and Background Color features) plugins.
 					// Color Button is only added just to show that text and background colors can be copied, too.
@@ -262,7 +262,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="3">
 				CKEDITOR.replace( 'editor3', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 295,
 					extraPlugins: 'copyformatting,colorbutton',
 					// Only allow Copy Formatting in plain text context.

--- a/docs/sdk/examples/copyformatting.html
+++ b/docs/sdk/examples/copyformatting.html
@@ -242,6 +242,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 255,
 					// Add Copy Formatting and Color Button (Text and Background Color features) plugins.
 					// Color Button is only added just to show that text and background colors can be copied, too.
@@ -251,6 +252,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					height: 450,
 					// Add Copy Formatting and Color Button (Text and Background Color features) plugins.
 					// Color Button is only added just to show that text and background colors can be copied, too.
@@ -260,6 +262,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="3">
 				CKEDITOR.replace( 'editor3', {
+					baseFloatZIndex: 10100,
 					height: 295,
 					extraPlugins: 'copyformatting,colorbutton',
 					// Only allow Copy Formatting in plain text context.

--- a/docs/sdk/examples/devtools.html
+++ b/docs/sdk/examples/devtools.html
@@ -64,6 +64,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					'#cke_tooltip ul { padding: 0pt; list-style-type: none; }';
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					extraPlugins: 'devtools'
 				} );

--- a/docs/sdk/examples/devtools.html
+++ b/docs/sdk/examples/devtools.html
@@ -64,7 +64,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					'#cke_tooltip ul { padding: 0pt; list-style-type: none; }';
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					extraPlugins: 'devtools'
 				} );

--- a/docs/sdk/examples/easyimage.html
+++ b/docs/sdk/examples/easyimage.html
@@ -227,6 +227,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					'.easyimage-gradient-2::before { background-image: linear-gradient( 135deg, rgba( 115, 110, 254, 0 ) 0%, rgba( 228, 66, 234, .72 ) 100% ); }' );
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'easyimage',
 					removePlugins: 'image',
 					removeDialogTabs: 'link:advanced',

--- a/docs/sdk/examples/easyimage.html
+++ b/docs/sdk/examples/easyimage.html
@@ -227,7 +227,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					'.easyimage-gradient-2::before { background-image: linear-gradient( 135deg, rgba( 115, 110, 254, 0 ) 0%, rgba( 228, 66, 234, .72 ) 100% ); }' );
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'easyimage',
 					removePlugins: 'image',
 					removeDialogTabs: 'link:advanced',

--- a/docs/sdk/examples/enterkey.html
+++ b/docs/sdk/examples/enterkey.html
@@ -44,7 +44,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 					// Create an editor instance again, with appropriate settings.
 					editor = CKEDITOR.replace( 'editor1', {
-	baseFloatZIndex: 10100,
+	baseFloatZIndex: 10005,
 						height: 120,
 						enterMode: Number( document.getElementById( 'xEnter' ).value ),
 						shiftEnterMode: Number( document.getElementById( 'xShiftEnter' ).value )
@@ -117,7 +117,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script type="template" data-sample="1">
 			&lt;script&gt;
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					// Pressing Enter will create a new &lt;div&gt; element.
 					enterMode: CKEDITOR.ENTER_DIV,
 					// Pressing Shift+Enter will create a new &lt;p&gt; element.

--- a/docs/sdk/examples/enterkey.html
+++ b/docs/sdk/examples/enterkey.html
@@ -36,20 +36,21 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<section class="sdk-contents">
 			<script>
 				var editor;
-		
+
 				function changeEnter() {
 					// If an editor instance exists, destroy it first.
 					if ( editor )
 						editor.destroy( true );
-		
+
 					// Create an editor instance again, with appropriate settings.
 					editor = CKEDITOR.replace( 'editor1', {
+	baseFloatZIndex: 10100,
 						height: 120,
 						enterMode: Number( document.getElementById( 'xEnter' ).value ),
 						shiftEnterMode: Number( document.getElementById( 'xShiftEnter' ).value )
 					});
 				}
-		
+
 				window.onload = changeEnter;
 			</script>
 			<h1>Enter Key Configuration <a class="documentation" href="https://ckeditor.com/docs/ckeditor4/latest/features/enterkey.html">Documentation</a></h1>
@@ -116,6 +117,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script type="template" data-sample="1">
 			&lt;script&gt;
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					// Pressing Enter will create a new &lt;div&gt; element.
 					enterMode: CKEDITOR.ENTER_DIV,
 					// Pressing Shift+Enter will create a new &lt;p&gt; element.

--- a/docs/sdk/examples/fileupload.html
+++ b/docs/sdk/examples/fileupload.html
@@ -133,6 +133,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 300,
 
 					// Configure your file manager integration. This example uses CKFinder 3 for PHP.
@@ -145,6 +146,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'uploadimage,image2',
 					height: 300,
 

--- a/docs/sdk/examples/fileupload.html
+++ b/docs/sdk/examples/fileupload.html
@@ -133,7 +133,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 300,
 
 					// Configure your file manager integration. This example uses CKFinder 3 for PHP.
@@ -146,7 +146,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'uploadimage,image2',
 					height: 300,
 

--- a/docs/sdk/examples/fixedui.html
+++ b/docs/sdk/examples/fixedui.html
@@ -106,7 +106,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250
 				} );
 
@@ -114,7 +114,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2" >
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					extraPlugins: 'divarea'
 				} );

--- a/docs/sdk/examples/fixedui.html
+++ b/docs/sdk/examples/fixedui.html
@@ -106,6 +106,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 250
 				} );
 
@@ -113,6 +114,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2" >
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					extraPlugins: 'divarea'
 				} );

--- a/docs/sdk/examples/format.html
+++ b/docs/sdk/examples/format.html
@@ -149,7 +149,7 @@ for each item in sequence S
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 280,
 					// List of text formats available for this editor instance.
 					format_tags: 'p;h1;h2;h3;h4;h5;h6;pre;address;div'
@@ -158,7 +158,7 @@ for each item in sequence S
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 280,
 					// Adding a custom stylesheet with some additional styles for text formats.
 					// Default CKEditor styles are included as well to avoid copying default styles.

--- a/docs/sdk/examples/format.html
+++ b/docs/sdk/examples/format.html
@@ -149,6 +149,7 @@ for each item in sequence S
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 280,
 					// List of text formats available for this editor instance.
 					format_tags: 'p;h1;h2;h3;h4;h5;h6;pre;address;div'
@@ -157,6 +158,7 @@ for each item in sequence S
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					height: 280,
 					// Adding a custom stylesheet with some additional styles for text formats.
 					// Default CKEditor styles are included as well to avoid copying default styles.

--- a/docs/sdk/examples/fullpage.html
+++ b/docs/sdk/examples/fullpage.html
@@ -91,6 +91,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					fullPage: true,
 					extraPlugins: 'docprops',
 					// Disable content filtering because if you use full page mode, you probably

--- a/docs/sdk/examples/fullpage.html
+++ b/docs/sdk/examples/fullpage.html
@@ -91,7 +91,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					fullPage: true,
 					extraPlugins: 'docprops',
 					// Disable content filtering because if you use full page mode, you probably

--- a/docs/sdk/examples/fullpreset.html
+++ b/docs/sdk/examples/fullpreset.html
@@ -117,6 +117,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
+				baseFloatZIndex: 10100,
 				height: 400
 			} );
 		</script>

--- a/docs/sdk/examples/fullpreset.html
+++ b/docs/sdk/examples/fullpreset.html
@@ -117,7 +117,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
-				baseFloatZIndex: 10100,
+				baseFloatZIndex: 10005,
 				height: 400
 			} );
 		</script>

--- a/docs/sdk/examples/htmlformatting.html
+++ b/docs/sdk/examples/htmlformatting.html
@@ -80,7 +80,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</div>
 			<script data-sample="1">
 				var editor1 = CKEDITOR.replace( 'editor1', {
-	baseFloatZIndex: 10100,
+	baseFloatZIndex: 10005,
 					extraAllowedContent : 'div',
 					height: 460
 				} );

--- a/docs/sdk/examples/htmlformatting.html
+++ b/docs/sdk/examples/htmlformatting.html
@@ -80,6 +80,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</div>
 			<script data-sample="1">
 				var editor1 = CKEDITOR.replace( 'editor1', {
+	baseFloatZIndex: 10100,
 					extraAllowedContent : 'div',
 					height: 460
 				} );

--- a/docs/sdk/examples/image.html
+++ b/docs/sdk/examples/image.html
@@ -125,7 +125,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.addCss( '.cke_editable { font-size: 15px; padding: 2em; }' );
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					toolbar: [
 						{ name: 'document', items: [ 'Print' ] },
 						{ name: 'clipboard', items: [ 'Undo', 'Redo' ] },

--- a/docs/sdk/examples/image.html
+++ b/docs/sdk/examples/image.html
@@ -125,6 +125,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.addCss( '.cke_editable { font-size: 15px; padding: 2em; }' );
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					toolbar: [
 						{ name: 'document', items: [ 'Print' ] },
 						{ name: 'clipboard', items: [ 'Undo', 'Redo' ] },

--- a/docs/sdk/examples/image2.html
+++ b/docs/sdk/examples/image2.html
@@ -94,7 +94,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'image2,uploadimage',
 
 					toolbar: [

--- a/docs/sdk/examples/image2.html
+++ b/docs/sdk/examples/image2.html
@@ -94,6 +94,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'image2,uploadimage',
 
 					toolbar: [

--- a/docs/sdk/examples/language.html
+++ b/docs/sdk/examples/language.html
@@ -108,7 +108,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'bidi',
 					// Setting default language direction to right-to-left.
 					contentsLangDirection: 'rtl',
@@ -118,7 +118,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'language',
 					// Customizing list of languages available in the Language drop-down.
 					language_list: [ 'ar:Arabic:rtl', 'fr:French',  'he:Hebrew:rtl', 'es:Spanish' ],

--- a/docs/sdk/examples/language.html
+++ b/docs/sdk/examples/language.html
@@ -108,6 +108,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'bidi',
 					// Setting default language direction to right-to-left.
 					contentsLangDirection: 'rtl',
@@ -117,6 +118,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'language',
 					// Customizing list of languages available in the Language drop-down.
 					language_list: [ 'ar:Arabic:rtl', 'fr:French',  'he:Hebrew:rtl', 'es:Spanish' ],

--- a/docs/sdk/examples/magicline.html
+++ b/docs/sdk/examples/magicline.html
@@ -105,7 +105,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: '500',
 					// Ensure that the Magic Line plugin, which is required for this sample, is loaded.
 					extraPlugins: 'magicline',

--- a/docs/sdk/examples/magicline.html
+++ b/docs/sdk/examples/magicline.html
@@ -105,6 +105,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: '500',
 					// Ensure that the Magic Line plugin, which is required for this sample, is loaded.
 					extraPlugins: 'magicline',

--- a/docs/sdk/examples/mathjax.html
+++ b/docs/sdk/examples/mathjax.html
@@ -55,7 +55,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'mathjax',
 					mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
 					height: 320

--- a/docs/sdk/examples/mathjax.html
+++ b/docs/sdk/examples/mathjax.html
@@ -55,6 +55,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'mathjax',
 					mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
 					height: 320

--- a/docs/sdk/examples/mathtype.html
+++ b/docs/sdk/examples/mathtype.html
@@ -119,6 +119,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					CKEDITOR.plugins.addExternal( 'ckeditor_wiris', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/ckeditor_wiris/', 'plugin.js' );
 
 					CKEDITOR.replace( 'editor1', {
+						baseFloatZIndex: 10100,
 						extraPlugins: 'ckeditor_wiris',
 						// For now, MathType is incompatible with CKEditor file upload plugins.
 						removePlugins: 'uploadimage,uploadwidget,uploadfile,filetools,filebrowser',

--- a/docs/sdk/examples/mathtype.html
+++ b/docs/sdk/examples/mathtype.html
@@ -119,7 +119,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					CKEDITOR.plugins.addExternal( 'ckeditor_wiris', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/ckeditor_wiris/', 'plugin.js' );
 
 					CKEDITOR.replace( 'editor1', {
-						baseFloatZIndex: 10100,
+						baseFloatZIndex: 10005,
 						extraPlugins: 'ckeditor_wiris',
 						// For now, MathType is incompatible with CKEditor file upload plugins.
 						removePlugins: 'uploadimage,uploadwidget,uploadfile,filetools,filebrowser',

--- a/docs/sdk/examples/mediaembed.html
+++ b/docs/sdk/examples/mediaembed.html
@@ -129,6 +129,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'embed,autoembed,image2',
 					height: 500,
 

--- a/docs/sdk/examples/mediaembed.html
+++ b/docs/sdk/examples/mediaembed.html
@@ -129,7 +129,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'embed,autoembed,image2',
 					height: 500,
 

--- a/docs/sdk/examples/mentions.html
+++ b/docs/sdk/examples/mentions.html
@@ -281,6 +281,7 @@
 					];
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					plugins: 'mentions,emoji,basicstyles,undo,link,wysiwygarea,toolbar',
 					contentsCss: [
 						CKEDITOR.basePath + 'contents.css',

--- a/docs/sdk/examples/mentions.html
+++ b/docs/sdk/examples/mentions.html
@@ -281,7 +281,7 @@
 					];
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					plugins: 'mentions,emoji,basicstyles,undo,link,wysiwygarea,toolbar',
 					contentsCss: [
 						CKEDITOR.basePath + 'contents.css',

--- a/docs/sdk/examples/pastefromexcel.html
+++ b/docs/sdk/examples/pastefromexcel.html
@@ -181,6 +181,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
+				baseFloatZIndex: 10100,
 				// Define the toolbar: https://ckeditor.com/docs/ckeditor4/latest/features/toolbar
 				// The full preset from CDN which we used as a base provides more features than we need.
 				// Also by default it comes with a 3-line toolbar. Here we put all buttons in a single row.

--- a/docs/sdk/examples/pastefromexcel.html
+++ b/docs/sdk/examples/pastefromexcel.html
@@ -181,7 +181,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
-				baseFloatZIndex: 10100,
+				baseFloatZIndex: 10005,
 				// Define the toolbar: https://ckeditor.com/docs/ckeditor4/latest/features/toolbar
 				// The full preset from CDN which we used as a base provides more features than we need.
 				// Also by default it comes with a 3-line toolbar. Here we put all buttons in a single row.

--- a/docs/sdk/examples/pastefromgoogledocs.html
+++ b/docs/sdk/examples/pastefromgoogledocs.html
@@ -165,7 +165,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
-				baseFloatZIndex: 10100,
+				baseFloatZIndex: 10005,
 				// Define the toolbar: https://ckeditor.com/docs/ckeditor4/latest/features/toolbar
 				// The full preset from CDN which we used as a base provides more features than we need.
 				// Also by default it comes with a 3-line toolbar. Here we put all buttons in a single row.

--- a/docs/sdk/examples/pastefromgoogledocs.html
+++ b/docs/sdk/examples/pastefromgoogledocs.html
@@ -165,6 +165,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
+				baseFloatZIndex: 10100,
 				// Define the toolbar: https://ckeditor.com/docs/ckeditor4/latest/features/toolbar
 				// The full preset from CDN which we used as a base provides more features than we need.
 				// Also by default it comes with a 3-line toolbar. Here we put all buttons in a single row.

--- a/docs/sdk/examples/pastefromword.html
+++ b/docs/sdk/examples/pastefromword.html
@@ -163,7 +163,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
-				baseFloatZIndex: 10100,
+				baseFloatZIndex: 10005,
 				// Define the toolbar: https://ckeditor.com/docs/ckeditor4/latest/features/toolbar
 				// The full preset from CDN which we used as a base provides more features than we need.
 				// Also by default it comes with a 3-line toolbar. Here we put all buttons in two rows.

--- a/docs/sdk/examples/pastefromword.html
+++ b/docs/sdk/examples/pastefromword.html
@@ -163,6 +163,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
+				baseFloatZIndex: 10100,
 				// Define the toolbar: https://ckeditor.com/docs/ckeditor4/latest/features/toolbar
 				// The full preset from CDN which we used as a base provides more features than we need.
 				// Also by default it comes with a 3-line toolbar. Here we put all buttons in two rows.

--- a/docs/sdk/examples/placeholder.html
+++ b/docs/sdk/examples/placeholder.html
@@ -59,6 +59,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'placeholder',
 					height: 220
 				} );

--- a/docs/sdk/examples/placeholder.html
+++ b/docs/sdk/examples/placeholder.html
@@ -59,7 +59,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'placeholder',
 					height: 220
 				} );

--- a/docs/sdk/examples/removeformat.html
+++ b/docs/sdk/examples/removeformat.html
@@ -101,6 +101,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					// Adding Text and Background Color, Font Family and Size buttons to make sample
 					// text styling more spectacular.

--- a/docs/sdk/examples/removeformat.html
+++ b/docs/sdk/examples/removeformat.html
@@ -101,7 +101,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					// Adding Text and Background Color, Font Family and Size buttons to make sample
 					// text styling more spectacular.

--- a/docs/sdk/examples/resize.html
+++ b/docs/sdk/examples/resize.html
@@ -118,7 +118,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					width: 600,
 					height: 300,
 					resize_dir: 'both',

--- a/docs/sdk/examples/resize.html
+++ b/docs/sdk/examples/resize.html
@@ -118,6 +118,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					width: 600,
 					height: 300,
 					resize_dir: 'both',

--- a/docs/sdk/examples/saveajax.html
+++ b/docs/sdk/examples/saveajax.html
@@ -135,7 +135,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				(function () {
 					var changesCount = 0;
 					var editor2 = CKEDITOR.replace( 'editor2', {
-	baseFloatZIndex: 10100,
+	baseFloatZIndex: 10005,
 						removePlugins: 'sourcearea'
 
 					} );

--- a/docs/sdk/examples/saveajax.html
+++ b/docs/sdk/examples/saveajax.html
@@ -35,29 +35,29 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<section class="sdk-contents">
 			<script data-sample="1">
 				var editor1, html = '';
-		
+
 				function createEditor() {
 					if ( editor1 )
 						return;
-		
+
 					// Create a new editor instance inside the <div id="editor"> element,
 					// setting its value to html.
 					var config = {};
 					editor1 = CKEDITOR.appendTo( 'editor1', config, html );
-		
+
 					// Update button states.
 					document.getElementById( 'remove' ).style.display = '';
 					document.getElementById( 'create' ).style.display = 'none';
 				}
-		
+
 				function removeEditor() {
 					if ( !editor1 )
 						return;
-		
+
 					// Retrieve the editor content. In an Ajax application this data would be
 					// sent to the server or used in any other way.
 					html = editor1.getData();
-		
+
 					// Update <div> with "Edited Content".
 					document.getElementById( 'editorcontent1' ).innerHTML = html;
 					// Show <div> with "Edited Content".
@@ -65,7 +65,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Update button states.
 					document.getElementById( 'remove' ).style.display = 'none';
 					document.getElementById( 'create' ).style.display = '';
-		
+
 					// Destroy the editor.
 					editor1.destroy();
 					editor1 = null;
@@ -135,6 +135,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				(function () {
 					var changesCount = 0;
 					var editor2 = CKEDITOR.replace( 'editor2', {
+	baseFloatZIndex: 10100,
 						removePlugins: 'sourcearea'
 
 					} );

--- a/docs/sdk/examples/sharedspace.html
+++ b/docs/sdk/examples/sharedspace.html
@@ -166,6 +166,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</ul>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'sharedspace',
 					removePlugins: 'maximize,resize',
 					height: 410,
@@ -176,6 +177,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				} );
 
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'sharedspace',
 					removePlugins: 'maximize,resize',
 					height: 410,

--- a/docs/sdk/examples/sharedspace.html
+++ b/docs/sdk/examples/sharedspace.html
@@ -166,7 +166,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</ul>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'sharedspace',
 					removePlugins: 'maximize,resize',
 					height: 410,
@@ -177,7 +177,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				} );
 
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'sharedspace',
 					removePlugins: 'maximize,resize',
 					height: 410,

--- a/docs/sdk/examples/simplebox.html
+++ b/docs/sdk/examples/simplebox.html
@@ -100,7 +100,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'simplebox', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/simplebox/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 
 					// Add the Simple Box plugin.
 					extraPlugins: 'simplebox',

--- a/docs/sdk/examples/simplebox.html
+++ b/docs/sdk/examples/simplebox.html
@@ -100,6 +100,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'simplebox', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/simplebox/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 
 					// Add the Simple Box plugin.
 					extraPlugins: 'simplebox',

--- a/docs/sdk/examples/size.html
+++ b/docs/sdk/examples/size.html
@@ -90,7 +90,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					width: '70%',
 					height: 500
 				} );

--- a/docs/sdk/examples/size.html
+++ b/docs/sdk/examples/size.html
@@ -90,6 +90,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					width: '70%',
 					height: 500
 				} );

--- a/docs/sdk/examples/sourcearea.html
+++ b/docs/sdk/examples/sourcearea.html
@@ -132,7 +132,7 @@ config.removePlugins = &amp;#39;sourcearea&amp;#39;;&lt;/pre&gt;
 				CKEDITOR.disableAutoInline = true;
 
 				CKEDITOR.replace( 'editor3', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'sourcedialog',
 					removePlugins: 'sourcearea'
 				} );

--- a/docs/sdk/examples/sourcearea.html
+++ b/docs/sdk/examples/sourcearea.html
@@ -132,6 +132,7 @@ config.removePlugins = &amp;#39;sourcearea&amp;#39;;&lt;/pre&gt;
 				CKEDITOR.disableAutoInline = true;
 
 				CKEDITOR.replace( 'editor3', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'sourcedialog',
 					removePlugins: 'sourcearea'
 				} );

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -125,6 +125,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					// Remove the WebSpellChecker plugin.
 					removePlugins: 'wsc',
@@ -137,6 +138,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					// Remove the SpellCheckAsYouType (SCAYT) plugin.
 					removePlugins: 'scayt'
@@ -152,6 +154,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				};
 
 				CKEDITOR.replace( 'editor3', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					// Remove the WebSpellChecker and SpellCheckAsYouType (SCAYT) plugins.
 					removePlugins: 'scayt,wsc',
@@ -167,6 +170,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="4">
 				CKEDITOR.replace( 'editor4', {
+					baseFloatZIndex: 10100,
 					height: 250,
 					// Remove the WebSpellChecker and SpellCheckAsYouType (SCAYT) plugins.
 					removePlugins: 'scayt,wsc',

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -125,7 +125,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					// Remove the WebSpellChecker plugin.
 					removePlugins: 'wsc',
@@ -138,7 +138,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					// Remove the SpellCheckAsYouType (SCAYT) plugin.
 					removePlugins: 'scayt'
@@ -154,7 +154,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				};
 
 				CKEDITOR.replace( 'editor3', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					// Remove the WebSpellChecker and SpellCheckAsYouType (SCAYT) plugins.
 					removePlugins: 'scayt,wsc',
@@ -170,7 +170,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="4">
 				CKEDITOR.replace( 'editor4', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 250,
 					// Remove the WebSpellChecker and SpellCheckAsYouType (SCAYT) plugins.
 					removePlugins: 'scayt,wsc',

--- a/docs/sdk/examples/standardpreset.html
+++ b/docs/sdk/examples/standardpreset.html
@@ -116,6 +116,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
+				baseFloatZIndex: 10100,
 				height: 400
 			} );
 		</script>

--- a/docs/sdk/examples/standardpreset.html
+++ b/docs/sdk/examples/standardpreset.html
@@ -116,7 +116,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
-				baseFloatZIndex: 10100,
+				baseFloatZIndex: 10005,
 				height: 400
 			} );
 		</script>

--- a/docs/sdk/examples/styles.html
+++ b/docs/sdk/examples/styles.html
@@ -173,6 +173,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'widget',
 					height: 300
 				} );
@@ -180,6 +181,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'autoembed,embedsemantic,image2,mathjax,codesnippet,font',
 					removeButtons: 'Font',
 					height: 300,
@@ -189,6 +191,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="3">
 				CKEDITOR.replace( 'editor3', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'stylesheetparser',
 					height: 300,
 

--- a/docs/sdk/examples/styles.html
+++ b/docs/sdk/examples/styles.html
@@ -173,7 +173,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'widget',
 					height: 300
 				} );
@@ -181,7 +181,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'autoembed,embedsemantic,image2,mathjax,codesnippet,font',
 					removeButtons: 'Font',
 					height: 300,
@@ -191,7 +191,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="3">
 				CKEDITOR.replace( 'editor3', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'stylesheetparser',
 					height: 300,
 

--- a/docs/sdk/examples/tabindex.html
+++ b/docs/sdk/examples/tabindex.html
@@ -61,6 +61,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script>
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					height: 150
 				} );
 			</script>

--- a/docs/sdk/examples/tabindex.html
+++ b/docs/sdk/examples/tabindex.html
@@ -61,7 +61,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script>
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					height: 150
 				} );
 			</script>

--- a/docs/sdk/examples/table.html
+++ b/docs/sdk/examples/table.html
@@ -171,7 +171,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'colordialog,tableresize',
 					height: 470
 				} );

--- a/docs/sdk/examples/table.html
+++ b/docs/sdk/examples/table.html
@@ -171,6 +171,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'colordialog,tableresize',
 					height: 470
 				} );

--- a/docs/sdk/examples/timestamp.html
+++ b/docs/sdk/examples/timestamp.html
@@ -67,6 +67,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'timestamp', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/timestamp/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'timestamp'
 				} );
 			</script>

--- a/docs/sdk/examples/timestamp.html
+++ b/docs/sdk/examples/timestamp.html
@@ -67,7 +67,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'timestamp', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/timestamp/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'timestamp'
 				} );
 			</script>

--- a/docs/sdk/examples/toolbar.html
+++ b/docs/sdk/examples/toolbar.html
@@ -144,7 +144,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					// Define the toolbar groups as it is a more accessible solution.
 					toolbarGroups: [
 						{"name":"basicstyles","groups":["basicstyles"]},

--- a/docs/sdk/examples/toolbar.html
+++ b/docs/sdk/examples/toolbar.html
@@ -144,6 +144,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					// Define the toolbar groups as it is a more accessible solution.
 					toolbarGroups: [
 						{"name":"basicstyles","groups":["basicstyles"]},

--- a/docs/sdk/examples/toolbarlocation.html
+++ b/docs/sdk/examples/toolbarlocation.html
@@ -80,6 +80,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					toolbarLocation: 'bottom',
 					// Remove some plugins that would conflict with the bottom
 					// toolbar position.

--- a/docs/sdk/examples/toolbarlocation.html
+++ b/docs/sdk/examples/toolbarlocation.html
@@ -80,7 +80,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					toolbarLocation: 'bottom',
 					// Remove some plugins that would conflict with the bottom
 					// toolbar position.

--- a/docs/sdk/examples/uicolor.html
+++ b/docs/sdk/examples/uicolor.html
@@ -83,6 +83,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					uiColor: '#CCEAEE'
 				} );
 			</script>

--- a/docs/sdk/examples/uicolor.html
+++ b/docs/sdk/examples/uicolor.html
@@ -83,7 +83,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					uiColor: '#CCEAEE'
 				} );
 			</script>

--- a/docs/sdk/examples/uicolorpicker.html
+++ b/docs/sdk/examples/uicolorpicker.html
@@ -92,6 +92,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					extraPlugins: 'uicolor'
 				} );
 			</script>

--- a/docs/sdk/examples/uicolorpicker.html
+++ b/docs/sdk/examples/uicolorpicker.html
@@ -92,7 +92,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					extraPlugins: 'uicolor'
 				} );
 			</script>

--- a/docs/sdk/examples/uilanguages.html
+++ b/docs/sdk/examples/uilanguages.html
@@ -123,7 +123,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Replace the <textarea id="editor1"> with an CKEditor
 					// instance, using default configurations.
 					editor = CKEDITOR.replace( 'editor1', {
-	baseFloatZIndex: 10100,
+	baseFloatZIndex: 10005,
 						language: languageCode,
 
 						on: {
@@ -146,7 +146,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script type="template" data-sample="1">
 			&lt;script&gt;
 				CKEDITOR.replace( 'editor1', {
-					baseFloatZIndex: 10100,
+					baseFloatZIndex: 10005,
 					language: 'es'
 				} );
 			&lt;/script&gt;

--- a/docs/sdk/examples/uilanguages.html
+++ b/docs/sdk/examples/uilanguages.html
@@ -123,6 +123,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Replace the <textarea id="editor1"> with an CKEditor
 					// instance, using default configurations.
 					editor = CKEDITOR.replace( 'editor1', {
+	baseFloatZIndex: 10100,
 						language: languageCode,
 
 						on: {
@@ -145,6 +146,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script type="template" data-sample="1">
 			&lt;script&gt;
 				CKEDITOR.replace( 'editor1', {
+					baseFloatZIndex: 10100,
 					language: 'es'
 				} );
 			&lt;/script&gt;


### PR DESCRIPTION
Since maximize have conflict with Umberto header:

![image](https://user-images.githubusercontent.com/1061942/67468597-1235b300-f64b-11e9-9884-fc0a50399d2c.png)

_https://ckeditor.com/docs/ckeditor4/latest/examples/table.html_

let's use higher `baseFloatZIndex` for all CKEditor samples.

One thing to make sure is that only samples code was adjusted (no snippets, etc were affected). I have checked it but might miss something.