### PR TITLE
Replace onload handler with event listener

### DIFF
--- a/docs/sdk/examples/enterkey.html
+++ b/docs/sdk/examples/enterkey.html
@@ -36,12 +36,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<section class="sdk-contents">
 			<script>
 				var editor;
-		
+
 				function changeEnter() {
 					// If an editor instance exists, destroy it first.
 					if ( editor )
 						editor.destroy( true );
-		
+
 					// Create an editor instance again, with appropriate settings.
 					editor = CKEDITOR.replace( 'editor1', {
 						height: 120,
@@ -49,8 +49,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						shiftEnterMode: Number( document.getElementById( 'xShiftEnter' ).value )
 					});
 				}
-		
-				window.onload = changeEnter;
+
+				window.addEventListener( 'load', changeEnter );
 			</script>
 			<h1>Enter Key Configuration <a class="documentation" href="https://ckeditor.com/docs/ckeditor4/latest/features/enterkey.html">Documentation</a></h1>
 


### PR DESCRIPTION
It looks like `window.onload` is overwritten by one of the external libraries on the production. That's why I've replaced it with the event listener, what should fix the issue.

Closes: ckeditor/ckeditor4#3575