### PR TITLE
Fix typos in README files

### DIFF
--- a/docs/features/magicline/README.md
+++ b/docs/features/magicline/README.md
@@ -44,7 +44,7 @@ This will change magic line's color to blue, as presented in the image below.
 
 To further enhance CKEditor's accessibility, the following {@link features/shortcuts/README keyboard shortcuts} are available for working with magic line:
 
-* <kbd>Shift+Ctrl+3</kbd> &ndash; Enables enetring content (by adding a new paragraph) **before** a problematic element.
+* <kbd>Shift+Ctrl+3</kbd> &ndash; Enables entering content (by adding a new paragraph) **before** a problematic element.
 * <kbd>Shift+Ctrl+4</kbd> &ndash; Enables entering content (by adding a new paragraph) **after** a problematic element.
 
 You can also adjust the keyboard shortcuts by setting the {@linkapi CKEDITOR.config.magicline_keystrokeNext CKEDITOR.config.magicline_keystrokeNext} and {@linkapi CKEDITOR.config.magicline_keystrokePrevious CKEDITOR.config.magicline_keystrokePrevious} configuration options, respectively. For example:

--- a/docs/features/shortcuts/README.md
+++ b/docs/features/shortcuts/README.md
@@ -50,8 +50,8 @@ The list below contains available keyboard shortcuts grouped by problem areas. Y
 
 * <kbd>Enter</kbd> (<kbd>Return</kbd>) &ndash; Ends a paragraph and starts a new one.
 * <kbd>Shift+Enter</kbd> &ndash; Adds a line break.
-* <kbd>Shift+Ctrl+3</kbd> &ndash; Enables enetring content (by adding a new paragraph) before a problematic element such as an image, table or `<div>` element that starts or ends a document, list, or even adjacent horizontal lines.
-* <kbd>Shift+Ctrl+4</kbd> &ndash; Enables enetring content (by adding a new paragraph) after a problematic element such as an image, table or `<div>` element that starts or ends a document, list, or even adjacent horizontal lines.
+* <kbd>Shift+Ctrl+3</kbd> &ndash; Enables entering content (by adding a new paragraph) before a problematic element such as an image, table or `<div>` element that starts or ends a document, list, or even adjacent horizontal lines.
+* <kbd>Shift+Ctrl+4</kbd> &ndash; Enables entering content (by adding a new paragraph) after a problematic element such as an image, table or `<div>` element that starts or ends a document, list, or even adjacent horizontal lines.
 * <kbd>Backspace</kbd>, <kbd>Del</kbd> &ndash; Deletes a character.
 * <kbd>Ctrl+Backspace</kbd>, <kbd>Ctrl+Del</kbd> &ndash; Deletes a word.
 


### PR DESCRIPTION
`s/enetring/entering/g`