### PR TITLE
Add guide about integrating with webpack

### DIFF
--- a/docs/guide/dev/integration/webpack/README.md
+++ b/docs/guide/dev/integration/webpack/README.md
@@ -16,11 +16,11 @@ For licensing, see LICENSE.md.
 	The sample of the integration is provided through the <a href="https://github.com/ckeditor/ckeditor4-webpack-template"><code>ckeditor4-webpack-template</code> GitHub template repository</a>. It can be used as a quick starting point for your project.
 </info-box>
 
-Integrating CKEditor 4 with Webpack requires few simple steps to prepare correct Webpack configuration to create working bundle.
+Integrating CKEditor 4 with webpack requires few simple steps to prepare correct webpack configuration to create working bundle.
 
 ## Basic Webpack Integration
 
-In order to use CKEditor 4 with Webpack, start with creating a new project:
+In order to use CKEditor 4 with webpack, start with creating a new project:
 
 ```sh
 mkdir ckeditor4-webpack

--- a/docs/guide/dev/integration/webpack/README.md
+++ b/docs/guide/dev/integration/webpack/README.md
@@ -1,0 +1,85 @@
+---
+category: integration
+order: 40
+url: guide/dev_webpack
+menu-title: Webpack Integration
+meta-title-short: Webpack Integration
+---
+<!--
+Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md.
+-->
+
+# CKEditor 4 WYSIWYG Editor Webpack Integration
+
+<info-box info="">
+	The sample of the integration is provided through the <a href="https://github.com/ckeditor/ckeditor4-webpack-template"><code>ckeditor4-webpack-template</code> GitHub template repository</a>.
+</info-box>
+
+Out of the box CKEditor 4 does not work correctly after being bundled using webpack. However integrating CKEditor 4 and webpack is not difficult and this tutorial shows how to achieve it.
+
+## Basic Integration
+
+In order to use CKEditor 4 with webpack, start with creating the new project:
+
+```sh
+mkdir my-project
+cd my-project
+npm init -y
+```
+
+After creating the project, install necessary development dependencies:
+
+```sh
+npm install --save-dev ckeditor4 webpack webpack-cli
+```
+
+After installing, create webpack configuration in `webpack.config.js` file. Sample configuration is presented below:
+
+```javascript
+'use strict';
+
+const path = require( 'path' );
+
+module.exports = {
+	mode: 'production',
+	devtool: 'source-map',
+
+	entry: path.resolve( __dirname, 'src', 'index.js' ),
+
+	output: {
+		path: path.resolve( __dirname, 'dist' ),
+		filename: 'app.js',
+		libraryTarget: 'umd'
+	}
+};
+```
+
+The next step is creating the source code, which will be contained in two files: `src/basePath.js` and `src/index.js`. The main file, `src/index.js`, should look like this:
+
+```javascript
+import './basePath.js';
+import 'ckeditor4';
+
+// Insert yout code here.
+```
+
+The remaining file, `src/basePath.js`, will contain only setting the correct path to CKEditor 4:
+
+```javascript
+window.CKEDITOR_BASEPATH = '/node_modules/ckeditor4/';
+```
+
+This variable has to be in the separate file to be loaded before `ckeditor4` package. It's needed to bypass the way in which webpack works, moving all imports before the code containing them.
+
+The final step is to build the app containing CKEditor 4:
+
+```javascript
+npx webpack
+```
+
+The bundled code will appear in `dist/app.js` file.
+
+## CKEditor 4 Webpack Integration Template
+
+The more complex integration, featuring also transpiling the code with Babel and minimizing with Terser, is available in [`ckeditor4-webpack-template` GitHub template repository](https://github.com/ckeditor/ckeditor4-webpack-template). It can be used as a starting point for web apps projects.

--- a/docs/guide/dev/integration/webpack/README.md
+++ b/docs/guide/dev/integration/webpack/README.md
@@ -13,18 +13,18 @@ For licensing, see LICENSE.md.
 # CKEditor 4 WYSIWYG Editor Webpack Integration
 
 <info-box info="">
-	The sample of the integration is provided through the <a href="https://github.com/ckeditor/ckeditor4-webpack-template"><code>ckeditor4-webpack-template</code> GitHub template repository</a>.
+	The sample of the integration is provided through the <a href="https://github.com/ckeditor/ckeditor4-webpack-template"><code>ckeditor4-webpack-template</code> GitHub template repository</a>. It can be used as a quick starting point for your project.
 </info-box>
 
-Out of the box CKEditor 4 does not work correctly after being bundled using webpack. However integrating CKEditor 4 and webpack is not difficult and this tutorial shows how to achieve it.
+Integrating CKEditor 4 with Webpack requires few simple steps to prepare correct Webpack configuration to create working bundle.
 
-## Basic Integration
+## Basic Webpack Integration
 
-In order to use CKEditor 4 with webpack, start with creating the new project:
+In order to use CKEditor 4 with Webpack, start with creating a new project:
 
 ```sh
-mkdir my-project
-cd my-project
+mkdir ckeditor4-webpack
+cd ckeditor4-webpack
 npm init -y
 ```
 
@@ -55,7 +55,7 @@ module.exports = {
 };
 ```
 
-The next step is creating the source code, which will be contained in two files: `src/basePath.js` and `src/index.js`. The main file, `src/index.js`, should look like this:
+The next step is creating the source code, which will be contained in two files: `src/basePath.js` and `src/index.js`. The main file, `src/index.js`, should look like below:
 
 ```javascript
 import './basePath.js';
@@ -78,8 +78,8 @@ The final step is to build the app containing CKEditor 4:
 npx webpack
 ```
 
-The bundled code will appear in `dist/app.js` file.
+The bundled code will appear in the `dist/app.js` file.
 
 ## CKEditor 4 Webpack Integration Template
 
-The more complex integration, featuring also transpiling the code with Babel and minimizing with Terser, is available in [`ckeditor4-webpack-template` GitHub template repository](https://github.com/ckeditor/ckeditor4-webpack-template). It can be used as a starting point for web apps projects.
+The more complex integration, featuring transpiling the code with Babel and minimizing with Terser, is available in [`ckeditor4-webpack-template` GitHub template repository](https://github.com/ckeditor/ckeditor4-webpack-template). It can be used as a starting point for web apps projects.

--- a/docs/guide/dev/integration/webpack/README.md
+++ b/docs/guide/dev/integration/webpack/README.md
@@ -62,6 +62,10 @@ import './basePath.js';
 import 'ckeditor4';
 
 // Insert yout code here.
+// The code below is a sample of using CKEditor 4.
+CKEDITOR.replace( 'app', {
+	extraPlugins: 'iframe'
+} );
 ```
 
 The remaining file, `src/basePath.js`, will contain only setting the correct path to CKEditor 4:
@@ -78,7 +82,22 @@ The final step is to build the app containing CKEditor 4:
 npx webpack
 ```
 
-The bundled code will appear in the `dist/app.js` file.
+The bundled code will appear in the `dist/app.js` file. It can be used on a webpage like a normal script:
+
+```html
+<!DOCTYPE html>
+	<html lang="en">
+		<head>
+			<meta charset="UTF-8">
+			<title>CKEditor 4 webpack sample</title>
+		</head>
+		<body>
+			<div id="app"></div>
+
+			<script src="<path to your project>/dist/app.js"></script>
+		</body>
+	</html>
+```
 
 ## CKEditor 4 Webpack Integration Template
 

--- a/docs/guide/dev/integration/webpack/README.md
+++ b/docs/guide/dev/integration/webpack/README.md
@@ -13,30 +13,30 @@ For licensing, see LICENSE.md.
 # CKEditor 4 WYSIWYG Editor Webpack Integration
 
 <info-box info="">
-	The sample of the integration is provided through the <a href="https://github.com/ckeditor/ckeditor4-webpack-template"><code>ckeditor4-webpack-template</code> GitHub template repository</a>. It can be used as a quick starting point for your project.
+	A working sample of the webpack integration is provided through the <a href="https://github.com/ckeditor/ckeditor4-webpack-template"><code>ckeditor4-webpack-template</code> GitHub template repository</a>. It can be used as a quick starting point for your project.
 </info-box>
 
-Integrating CKEditor 4 with webpack requires few simple steps to prepare correct webpack configuration to create working bundle.
+Integrating CKEditor 4 with webpack requires a few simple steps to prepare a correct webpack configuration for a working bundle.
 
 ## Basic Webpack Integration
 
-In order to use CKEditor 4 with webpack, start with creating a new project:
+In order to use CKEditor 4 with webpack, create a new project:
 
-```sh
+```
 mkdir ckeditor4-webpack
 cd ckeditor4-webpack
 npm init -y
 ```
 
-After creating the project, install necessary development dependencies:
+After creating the project, install the necessary development dependencies:
 
-```sh
+```
 npm install --save-dev ckeditor4 webpack webpack-cli
 ```
 
-After installing, create webpack configuration in `webpack.config.js` file. Sample configuration is presented below:
+After installing, create the webpack configuration in the `webpack.config.js` file. A configuration example is presented below:
 
-```javascript
+```js
 'use strict';
 
 const path = require( 'path' );
@@ -57,28 +57,28 @@ module.exports = {
 
 The next step is creating the source code, which will be contained in two files: `src/basePath.js` and `src/index.js`. The main file, `src/index.js`, should look like below:
 
-```javascript
+```js
 import './basePath.js';
 import 'ckeditor4';
 
-// Insert yout code here.
-// The code below is a sample of using CKEditor 4.
+// Insert your code here.
+// The code below is an example of using CKEditor 4.
 CKEDITOR.replace( 'app', {
 	extraPlugins: 'iframe'
 } );
 ```
 
-The remaining file, `src/basePath.js`, will contain only setting the correct path to CKEditor 4:
+The remaining file, `src/basePath.js`, will be used to set the correct path to CKEditor 4:
 
-```javascript
+```js
 window.CKEDITOR_BASEPATH = '/node_modules/ckeditor4/';
 ```
 
-This variable has to be in the separate file to be loaded before `ckeditor4` package. It's needed to bypass the way in which webpack works, moving all imports before the code containing them.
+This variable needs to be in a separate file that has to be loaded before the `ckeditor4` package. This is needed to bypass the way in which webpack works, moving all imports before the code containing them.
 
-The final step is to build the app containing CKEditor 4:
+The final step is to build the application containing CKEditor 4 WYSIWYG editor:
 
-```javascript
+```js
 npx webpack
 ```
 
@@ -101,4 +101,4 @@ The bundled code will appear in the `dist/app.js` file. It can be used on a webp
 
 ## CKEditor 4 Webpack Integration Template
 
-The more complex integration, featuring transpiling the code with Babel and minimizing with Terser, is available in [`ckeditor4-webpack-template` GitHub template repository](https://github.com/ckeditor/ckeditor4-webpack-template). It can be used as a starting point for web apps projects.
+A more complex integration, featuring transpiling the code with Babel and minimizing with Terser, is available in the dedicated [`ckeditor4-webpack-template` GitHub template repository](https://github.com/ckeditor/ckeditor4-webpack-template). It can be used as a starting point for web application projects.


### PR DESCRIPTION
I've added guide with minimal, basic integration with webpack.

I've also created sample repository with such integration: https://github.com/ckeditor/ckeditor4-webpack-template

Closes ckeditor/ckeditor4#3045.