### PR TITLE
Fix for: Outdated "npm install --save ckeditor" after NPM package renaming

### DIFF
--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -19,7 +19,7 @@ The aim of this article is to get you up and running with CKEditor in two minute
 To install [the official CKEditor 4 NPM package](https://www.npmjs.com/package/ckeditor4) run:
 
 ```bash
-npm install ckeditor4 --save
+npm install ckeditor4
 ```
 
 For more detailed information you can check the guide on {@link guide/dev/package_managers/README Installing CKEditor 4 with Package Managers}.
@@ -47,7 +47,7 @@ Instead of downloading CKEditor 4 to your server and hosting it you can also use
 To install the Official CKEditor 4 Angular Component run:
 
 ```bash
-npm install ckeditor4-angular --save
+npm install ckeditor4-angular
 ```
 
 By default it will automatically fetch the latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/angular/README integration guides} on how it can be changed and how to configure the component to fit you needs.
@@ -57,7 +57,7 @@ By default it will automatically fetch the latest CKEditor 4 [Standard-All prese
 To install the Official CKEditor 4 React Component run:
 
 ```bash
-npm install ckeditor4-react --save
+npm install ckeditor4-react
 ```
 
 By default it will automatically fetch the latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/react/README integration guides} on how it can be changed and how to configure the component to fit you needs.

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -16,10 +16,10 @@ The aim of this article is to get you up and running with CKEditor in two minute
 
 ## Install from the NPM registry
 
-To install [the official CKEditor 4 NPM package](https://www.npmjs.com/package/ckeditor) run:
+To install [the official CKEditor 4 NPM package](https://www.npmjs.com/package/ckeditor4) run:
 
 ```bash
-npm install --save ckeditor
+npm install ckeditor4 --save
 ```
 
 For more detailed information you can check the guide on {@link guide/dev/package_managers/README Installing CKEditor 4 with Package Managers}.
@@ -28,17 +28,17 @@ For more detailed information you can check the guide on {@link guide/dev/packag
 
 ### Download
 
-Visit the official [CKEditor Download](https://ckeditor.com/ckeditor-4/download/) site. For a production site we recommend you choose the default **Standard Package** and click the **Download CKEditor** button to get the `.zip` installation file. If you want to try out more editor features, you can download the **Full Package** instead.
+Visit the official [CKEditor 4 Download](https://ckeditor.com/ckeditor-4/download/) site. For a production site we recommend you choose the default **Standard Package** and click the **Download** button to get the `.zip` installation file. If you want to try out more editor features, you can download the **Full Package** instead.
 
-<a href="https://ckeditor.com/ckeditor-4/download/"><img src="%BASE_PATH%/assets/img/ckeditor_quick_start_download.png" alt="CKEditor Download site" width="914" height="440"/></a>
+<a href="https://ckeditor.com/ckeditor-4/download/"><img src="%BASE_PATH%/assets/img/ckeditor_quick_start_download.png" alt="CKEditor 4 Download site" width="914" height="440"/></a>
 
 ### Unpacking
 
-Unpack (extract) the downloaded `.zip` archive to the `ckeditor` directory in the root of your website.
+Unpack (extract) the downloaded `.zip` archive to the `ckeditor4` directory in the root of your website.
 
 ## Using the CDN
 
-Instead of downloading CKEditor to your server and hosting it you can also use the CDN version. Go to the [official CKEditor CDN](http://cdn.ckeditor.com/) page for more details.
+Instead of downloading CKEditor 4 to your server and hosting it you can also use the CDN version. Go to the [official CKEditor CDN](http://cdn.ckeditor.com/) page for more details.
 
 ## Integrate with popular frameworks
 
@@ -47,7 +47,7 @@ Instead of downloading CKEditor to your server and hosting it you can also use t
 To install the Official CKEditor 4 Angular Component run:
 
 ```bash
-npm install --save ckeditor4-angular
+npm install ckeditor4-angular --save
 ```
 
 By default it will automatically fetch the latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/angular/README integration guides} on how it can be changed and how to configure the component to fit you needs.
@@ -57,7 +57,7 @@ By default it will automatically fetch the latest CKEditor 4 [Standard-All prese
 To install the Official CKEditor 4 React Component run:
 
 ```bash
-npm install --save ckeditor4-react
+npm install ckeditor4-react --save
 ```
 
 By default it will automatically fetch the latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/react/README integration guides} on how it can be changed and how to configure the component to fit you needs.
@@ -68,15 +68,15 @@ By default it will automatically fetch the latest CKEditor 4 [Standard-All prese
 
 ## Trying Out
 
-CKEditor comes with a sample that you can check to verify if the installation was successful as well as a few "next steps" ideas and references to further resources.
+CKEditor 4 comes with a sample that you can check to verify if the installation was successful as well as a few "next steps" ideas and references to further resources.
 
 Open the following page in the browser to see the sample:
-`http://<your site="">/ckeditor/samples/index.html`
+`http://<your site="">/ckeditor4/samples/index.html`
 
 When using the NPM package open the following:
-`http://<your site="">/node_modules/ckeditor/samples/index.html`
+`http://<your site="">/node_modules/ckeditor4/samples/index.html`
 
-<img src="%BASE_PATH%/assets/img/ckeditor_sample.png" alt="CKEditor sample available in each installation package" width="802" height="530">
+<img src="%BASE_PATH%/assets/img/ckeditor_sample.png" alt="CKEditor 4 sample available in each installation package" width="802" height="530">
 
 Additionally, you can click the Toolbar Configurator button on the editor sample page to open a handy tool that will let you {@link features/toolbar/README adjust the toolbar} to your needs.
 
@@ -86,7 +86,7 @@ If the sample works correctly, you are ready to build your own site with CKEdito
 
 To start, create a simple HTML page with a `<textarea>` element in it. You will then need to do two things:
 
-1. Include the  `<script>` element loading CKEditor in your page.
+1. Include the `<script>` element loading CKEditor 4 in your page.
 2. Use the {@linkapi CKEDITOR#replace `CKEDITOR.replace()`} method to replace the existing `<textarea>` element with CKEditor.
 
 See the following example:
@@ -117,19 +117,19 @@ See the following example:
 
 When you are done, open your test page in the browser.
 
-**Congratulations! You have just installed and used CKEditor on your own page in virtually no time!**
+**Congratulations! You have just installed and used CKEditor 4 on your own page in virtually no time!**
 
 {@img assets/img/ckeditor_on_page.png CKEditor added to your sample page}
 
 ## Next Steps
 
-Go ahead and play a bit more with the sample; try to change your configuration as suggested to customize it. And when you are ready to dive a bit deeper into CKEditor, you can try the following:
+Go ahead and play a bit more with the sample; try to change your configuration as suggested to customize it. And when you are ready to dive a bit deeper into CKEditor 4, you can try the following:
 
 1. Check the {@link guide/dev/configuration/README Setting Configuration} article to see how to adjust the editor to your needs.
-1. Get familiar with {@link guide/dev/acf/README Advanced Content Filter}. This is a useful tool that adjusts the content inserted into CKEditor to the features that are enabled and filters out disallowed content.
+1. Get familiar with {@link guide/dev/acf/README Advanced Content Filter}. This is a useful tool that adjusts the content inserted into CKEditor 4 to the features that are enabled and filters out disallowed content.
 1. {@link features/toolbar/README Modify your toolbar} to only include the features that you need. You can find the useful visual toolbar configurator directly in your editor sample.
-1. Learn about CKEditor features in the {@link features/index Features Overview} section.
+1. Learn about CKEditor 4 features in the {@link features/index Features Overview} section.
 1. Visit the {@linksdk index CKEditor Examples} to see the **huge collection of working editor samples** showcasing its features, with source code readily available to see and download.
 1. Browse the [Add-ons Repository](https://ckeditor.com/cke4/addons/plugins/all) for some additional plugins or skins.
-1. Use [online builder](https://ckeditor.com/cke4/builder) to create your custom CKEditor build.
-1. Browse the {@link guide/index Developer's Guide} for some further ideas on what to do with CKEditor and join the CKEditor community at [Stack Overflow](http://stackoverflow.com/questions/tagged/ckeditors) to discuss all things CKEditor with fellow developers!
+1. Use [online builder](https://ckeditor.com/cke4/builder) to create your custom CKEditor 4 build.
+1. Browse the {@link guide/index Developer's Guide} for some further ideas on what to do with CKEditor 4 and join the CKEditor community at [Stack Overflow](http://stackoverflow.com/questions/tagged/ckeditor) to discuss all CKEditor things with fellow developers!

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -23,7 +23,7 @@ CKEditor 4 offers a native Angular integration through the CKEditor 4 Angular co
 In order to create an editor instance in Angular, install the `ckeditor4-angular` npm package as a dependency of your project:
 
 ```bash
-npm install --save ckeditor4-angular
+npm install ckeditor4-angular
 ```
 
 After installing, import `CKEditorModule` to your application:

--- a/docs/guide/dev/integration/react/README.md
+++ b/docs/guide/dev/integration/react/README.md
@@ -23,7 +23,7 @@ CKEditor 4 offers a native React integration through the CKEditor 4 React compon
 In order to create an editor instance in React, install the `ckeditor4-react` npm package as a dependency of your project:
 
 ```plaintext
-npm install --save ckeditor4-react
+npm install ckeditor4-react
 ```
 
 After installing, the CKEditor 4 React component can be imported in your JavaScript code:

--- a/docs/guide/dev/integration/spreadsheets/README.md
+++ b/docs/guide/dev/integration/spreadsheets/README.md
@@ -29,7 +29,7 @@ There are a few methods that you can use in order to add the Spreadsheet plugin 
 The Spreadsheet plugin for CKEditor 4 is available through npm. To use it, install the `ckeditor4-plugin-spreadsheet` npm package as a dependency of your project:
 
 ```plaintext
-npm install --save ckeditor4-plugin-spreadsheet
+npm install ckeditor4-plugin-spreadsheet
 ```
 
 If CKEditor 4 was also installed through npm (using the `ckeditor4` package) in your project, the plugin will create a symbolic link itself in the CKEditor 4 `plugins/` directory so you do not need to move or copy any files.

--- a/docs/guide/dev/package_managers/README.md
+++ b/docs/guide/dev/package_managers/README.md
@@ -48,11 +48,11 @@ By default CKEditor will be placed in the `node_modules/ckeditor4` directory.
 
 ### Adding CKEditor 4 as a Dependency Using the `package.json` File
 
-You may add CKEditor 4 to the dependencies list by using the `--save` flag:
+Using `npm install` command will automatically create a reference to `ckeditor4` in your `package.json` file:
 
-    npm install ckeditor4 --save
+    npm install ckeditor4
 
-or by manually editing your `package.json` file. Just make sure to create a reference to `ckeditor4` in the `dependencies` property.
+You should see the following reference in the `dependencies` property:
 
 ```js
 {

--- a/docs/guide/dev/package_managers/README.md
+++ b/docs/guide/dev/package_managers/README.md
@@ -23,9 +23,9 @@ For example, if you wanted to add the **Text Color** and **Background Color** bu
 
 	config.extraPlugins = 'colorbutton';
 
-## Custom CKEditor Configuration
+## Custom CKEditor 4 Configuration
 
-If you want to use package managers to keep CKEditor up to date, your custom editor configuration should not be done in any of the core CKEditor files like `config.js` (otherwise you risk overwriting them during the update process).
+If you want to use package managers to keep CKEditor 4 up to date, your custom editor configuration should not be done in any of the core CKEditor files like `config.js` (otherwise you risk overwriting them during the update process).
 
 It is thus recommended to use of the following strategies:
 
@@ -42,23 +42,23 @@ This article assumes that you have **npm** already installed and added to your `
 
 In order to fetch the most recent build, execute the following command:
 
-	npm install ckeditor
+	npm install ckeditor4
 
-By default CKEditor will be placed in the `node_modules/ckeditor` directory.
+By default CKEditor will be placed in the `node_modules/ckeditor4` directory.
 
-### Adding CKEditor as a Dependency Using the `package.json` File
+### Adding CKEditor 4 as a Dependency Using the `package.json` File
 
-You may add CKEditor to the dependencies list by using the `--save` flag:
+You may add CKEditor 4 to the dependencies list by using the `--save` flag:
 
-    npm install ckeditor --save
+    npm install ckeditor4 --save
 
-or by manually editing your `package.json` file. Just make sure to create a reference to `ckeditor` in the `dependencies` property.
+or by manually editing your `package.json` file. Just make sure to create a reference to `ckeditor4` in the `dependencies` property.
 
 ```js
 {
     "name": "my-project",
     "dependencies": {
-        "ckeditor": "4.11.0"
+        "ckeditor4": "4.13.0"
     }
 }
 ```
@@ -69,7 +69,7 @@ Then execute the following command:
 
 ### Fetching a Particular Build Preset
 
-Currently only the `standard-all` CKEditor installation preset can be fetched.
+Currently only the `standard-all` CKEditor 4 installation preset can be fetched.
 
 ## Bower
 
@@ -81,11 +81,11 @@ In order to fetch the most recent build, execute the following command:
 
 	bower install ckeditor
 
-By default CKEditor will be placed in the `bower_components/ckeditor` directory.
+By default CKEditor 4 will be placed in the `bower_components/ckeditor` directory.
 
-### Adding CKEditor as a Dependency Using the `bower.json` File
+### Adding CKEditor 4 as a Dependency Using the `bower.json` File
 
-You may add CKEditor to the dependencies list inside your `bower.json` file. Just make sure to create a reference to `ckeditor` in the `dependencies` property.
+You may add CKEditor 4 to the dependencies list inside your `bower.json` file. Just make sure to create a reference to `ckeditor` in the `dependencies` property.
 
 ```js
 {
@@ -104,9 +104,9 @@ Then execute the following command:
 
 By default only the `standard-all` CKEditor installation preset can be fetched. However, there is a workaround to install a diffrent package using the `#<preset>/<version>` syntax.
 
-For example, if you would like to download the `full` preset of CKEditor 4.11.0, execute the following command:
+For example, if you would like to download the `full` preset of CKEditor 4.13.0, execute the following command:
 
-	bower install ckeditor#full/4.11.0
+	bower install ckeditor#full/4.13.0
 
 ## Composer
 
@@ -114,7 +114,7 @@ This article assumes that you have **Composer** already up and running. If this 
 
 ### Usage
 
-In order to fetch the most recent CKEditor 4 build, create a `composer.json` file in the directory where you want to install CKEditor. This file should include the  following contents:
+In order to fetch the most recent CKEditor 4 build, create a `composer.json` file in the directory where you want to install CKEditor. This file should include the following contents:
 
 ```js
 {
@@ -130,7 +130,7 @@ Then execute the following command:
 
 ### Fetching a Particular Build Preset
 
-There is a way for Composer to fetch CKEditor built with a desired preset. For each preset you can subscribe to the following branches:
+There is a way for Composer to fetch CKEditor 4 built with a desired preset. For each preset you can subscribe to the following branches:
 
 1. Latest release
 2. Stable release
@@ -142,14 +142,14 @@ preset | standard-all | basic | standard | full
  --- | --- | --- | --- | ---
 latest | `dev-latest` | `dev-basic/latest` | `dev-standard/latest` | `dev-full/latest`
 stable | `dev-stable` | `dev-basic/stable` | `dev-standard/stable` | `dev-full/stable`
-4.11.x | `4.11.x-dev` | `dev-basic/4.11.x` | `dev-standard/4.11.x` | `dev-full/4.11.x`
+4.13.x | `4.13.x-dev` | `dev-basic/4.13.x` | `dev-standard/4.13.x` | `dev-full/4.13.x`
 
-For example, let us consider that we want to include the `full` preset of the most up-to-date `4.11.x` release. In this case the `composer.json` file should contain the following code:
+For example, let us consider that we want to include the `full` preset of the most up-to-date `4.13.x` release. In this case the `composer.json` file should contain the following code:
 
 ```js
 {
     "require": {
-        "ckeditor/ckeditor": "dev-full/4.11.x"
+        "ckeditor/ckeditor": "dev-full/4.13.x"
     }
 }
 ```
@@ -180,4 +180,4 @@ e.g.
 
 	nuget install ckeditor-standard
 
-You will find the package installed into a directory like `ckeditor-standard.4.11.0`.
+You will find the package installed into a directory like `ckeditor-standard.4.13.0`.


### PR DESCRIPTION
Leftovers after renaming repos to `ckeditor4` etc.

Also removes obsolete option `--save` from `npm` listings (as a separate commit).

Closes [ckeditor4#3697](https://github.com/ckeditor/ckeditor4/issues/3697).