### PR TITLE
Remove 'ckeditor4-docs-samples' from docs submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "repos/ckeditor-presets"]
 	path = repos/ckeditor-presets
 	url = https://github.com/ckeditor/ckeditor4-presets.git
-[submodule "docs/sdk/examples/assets/ckeditor-docs-samples"]
-	path = docs/sdk/examples/assets/ckeditor-docs-samples
-	url = https://github.com/ckeditor/ckeditor4-docs-samples.git


### PR DESCRIPTION
Besides just removing this repo from `.gitmodules` I also had to make some changes in git files (as described [here](https://gist.github.com/myusuf3/7f645819ded92bda6677)).

Closes [ckeditor/ckeditor4#3897](https://github.com/ckeditor/ckeditor4/issues/3897).