### PR TITLE
Fix link to jQuery integration guide

### DIFF
--- a/docs/guide/dev/integration/README.md
+++ b/docs/guide/dev/integration/README.md
@@ -40,7 +40,7 @@ When checking how to integrate CKEditor 4 with your framework you can follow the
 	There are four official integrations so far: for {@link guide/dev/integration/react/README React}, {@link guide/dev/integration/angular/README Angular}, {@link guide/dev/integration/vue/README Vue.js} and {@link guide/dev/integration/jquery/README jQuery}.
 
 2. **If not, search for community-driven integrations.** Most of them are available on [npm](https://www.npmjs.com/).
-3. **If none exists, integrate CKEditor 4 with your framework by yourself.**
+3. **If none exists, integrate CKEditor 4 with your framework by yourself and share it with the world!**
 
 ### Official WYSIWYG Editor Integrations
 
@@ -49,7 +49,7 @@ There are four official integrations so far:
 * **{@link guide/dev/integration/angular/README CKEditor 4 WYSIWYG editor for Angular}**
 * **{@link guide/dev/integration/react/README CKEditor 4 WYSIWYG editor for React}**
 * **{@link guide/dev/integration/vue/README CKEditor 4 WYSIWYG editor for Vue.js}**
-* **{@link guide/dev/integration/vue/README CKEditor 4 WYSIWYG editor for jQuery}**
+* **{@link guide/dev/integration/jquery/README CKEditor 4 WYSIWYG editor for jQuery}**
 
 Refer to their documentation to learn how to use them.
 


### PR DESCRIPTION
Besides fixing the link, I added half a sentence to encourage people to share their custom integrations. And now there is also a new empty line at the end of file.

Closes [ckeditor/ckeditor4#3914](https://github.com/ckeditor/ckeditor4/issues/3914).