### PR TITLE
Fix a typo - "filer" instead of "filter"

### DIFF
--- a/docs/features/copyformatting/README.md
+++ b/docs/features/copyformatting/README.md
@@ -117,7 +117,7 @@ See the {@linksdk copyformatting working "Using the Copy Formatting Feature" sam
 
 Refer to the following resources for more information about text styling and formatting:
 
-* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filer} article contains more in-depth technical details about ACF.
+* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filter} article contains more in-depth technical details about ACF.
 * The {@link guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README Allowed Content Rules} article explains the allowed and disallowed content rules format.
 * The {@link features/basicstyles/README Basic Text Styles: Bold, Italic and More} article explains how to apply bold, italic, underline, strikethrough, subscript and superscript formatting to text selections.
 * The {@link features/removeformat/README Removing Text Formatting} article explains how to quickly remove any text formatting that is applied through inline HTML elements and CSS styles.

--- a/docs/guide/dev/acf/README.md
+++ b/docs/guide/dev/acf/README.md
@@ -153,7 +153,7 @@ The following samples are available for two ACF modes:
 
 Refer to the following resources for more information about content filtering:
 
-* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filer} article contains more in-depth technical details about ACF.
+* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filter} article contains more in-depth technical details about ACF.
 * The {@link guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README Allowed Content Rules} article explains the allowed and disallowed content rules format.
 * The {@link guide/dev/deep_dive/advanced_content_filter/disallowed_content/README Disallowed Content} article explains how blacklisting works in ACF.
 * The {@link guide/plugin_sdk/integration_with_acf/README Integrating Plugins with Advanced Content Filter} article explains how to adjust custom plugins to properly implement content filtering.

--- a/docs/guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README.md
+++ b/docs/guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README.md
@@ -225,6 +225,6 @@ The `propertiesOnly` property means that this rule will only accept properties &
 Refer to the following resources for more information about content filtering:
 
 * The {@link guide/dev/acf/README Content Filtering (ACF)} article explains some ACF use cases and the rationale behind this feature.
-* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filer} article contains more in-depth technical details about ACF.
+* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filter} article contains more in-depth technical details about ACF.
 * The {@link guide/dev/deep_dive/advanced_content_filter/disallowed_content/README Disallowed Content} article explains how blacklisting works in ACF.
 * The {@link guide/plugin_sdk/integration_with_acf/README Integrating Plugins with Advanced Content Filter} article explains how to adjust custom plugins to properly implement content filtering.

--- a/docs/guide/dev/deep_dive/advanced_content_filter/disallowed_content/README.md
+++ b/docs/guide/dev/deep_dive/advanced_content_filter/disallowed_content/README.md
@@ -99,6 +99,6 @@ The above code sample will allow everything except for the `<script>` elements a
 Refer to the following resources for more information about content filtering:
 
 * The {@link guide/dev/acf/README Content Filtering (ACF)} article explains some ACF use cases and the rationale behind this feature.
-* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filer} article contains more in-depth technical details about ACF.
+* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filter} article contains more in-depth technical details about ACF.
 * The {@link guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README Allowed Content Rules} article explains the allowed and disallowed content rules format.
 * The {@link guide/plugin_sdk/integration_with_acf/README Integrating Plugins with Advanced Content Filter} article explains how to adjust custom plugins to properly implement content filtering.

--- a/docs/guide/plugin_sdk/integration_with_acf/README.md
+++ b/docs/guide/plugin_sdk/integration_with_acf/README.md
@@ -271,7 +271,7 @@ Refer to the following resources for more information about creating CKEditor pl
 Refer to the following resources for more information about content filtering:
 
 * The {@link guide/dev/acf/README Content Filtering (ACF)} article explains some ACF use cases and the rationale behind this feature.
-* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filer} article contains more in-depth technical details about ACF.
+* The {@link guide/dev/deep_dive/advanced_content_filter/README Advanced Content Filter} article contains more in-depth technical details about ACF.
 * The {@link guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README Allowed Content Rules} article explains the allowed and disallowed content rules format.
 * The {@link guide/dev/deep_dive/advanced_content_filter/disallowed_content/README Disallowed Content} article explains how blacklisting works in ACF.
 * {@linkapi CKEDITOR.filter CKEDITOR.filter} contains API documentation for the main class responsible for ACF features.


### PR DESCRIPTION
In accordance to Advanced Content Filter.