### PR TITLE
Add note about IE mode in Edge

### DIFF
--- a/docs/guide/dev/browsers/README.md
+++ b/docs/guide/dev/browsers/README.md
@@ -22,8 +22,9 @@ The list of officially supported browsers contains those which the CKEditor core
   * **Internet Explorer**:
     * 8.0 and 9.0 &ndash; close to full support,
     * 10 and 11 &ndash; full support,
+    * IE mode in Microsoft Edge &ndash; full support,
     * 9.0 Quirks Mode and 9.0 Compatibility Mode &ndash; limited support.
-  * **Firefox, Chrome, Safari, Microsoft Edge (including IE mode), Opera**:
+  * **Firefox, Chrome, Safari, Microsoft Edge, Opera**:
     * Latest stable release &ndash; full support.
 * **Mobile environments**:
   * **Safari** (iOS 6+) &ndash; close to full support,

--- a/docs/guide/dev/browsers/README.md
+++ b/docs/guide/dev/browsers/README.md
@@ -23,7 +23,7 @@ The list of officially supported browsers contains those which the CKEditor core
     * 8.0 and 9.0 &ndash; close to full support,
     * 10 and 11 &ndash; full support,
     * 9.0 Quirks Mode and 9.0 Compatibility Mode &ndash; limited support.
-  * **Firefox, Chrome, Safari, Microsoft Edge, Opera**:
+  * **Firefox, Chrome, Safari, Microsoft Edge (including IE mode), Opera**:
     * Latest stable release &ndash; full support.
 * **Mobile environments**:
   * **Safari** (iOS 6+) &ndash; close to full support,


### PR DESCRIPTION
As not much changed in Edge support after switch from edgeHTML to Chromium engine, adding just an inline mention that IE mode is supported should be enough.

Closes [ckeditor/ckeditor4#3882](https://github.com/ckeditor/ckeditor4/issues/3882).