### PR TITLE
Follow up task after merging Examples to docs building process

### DIFF
--- a/docs/features/accessibility_checker/README.md
+++ b/docs/features/accessibility_checker/README.md
@@ -289,7 +289,7 @@ Please note that the predefined keyboard shortcuts can be changed with the custo
 
 ## Accessibility Checker Demo
 
-See the {@linksdk accessibilitychecker working "Accessibility Checker" sample} where you can try how to detect and fix accessibility issues in your editor content.
+See the {@linkexample accessibilitychecker working "Accessibility Checker" sample} where you can try how to detect and fix accessibility issues in your editor content.
 
 ## Related Features
 

--- a/docs/features/autocomplete/README.md
+++ b/docs/features/autocomplete/README.md
@@ -174,9 +174,9 @@ You can review and download the complete solution in the [documentation code sam
 
 ## Autocomplete Demos
 
-See the {@linksdk autocomplete working "Autocomplete" sample} to check how autocomplete helps create a useful templating system, saving your time and limiting the opportunity to make mistakes.
+See the {@linkexample autocomplete working "Autocomplete" sample} to check how autocomplete helps create a useful templating system, saving your time and limiting the opportunity to make mistakes.
 
-Check the {@linksdk autotag "Autotag Plugin (Creating a Custom Autocomplete Plugin)"} sample to see the working Autotag plugin created in this tutorial.
+Check the {@linkexample autotag "Autotag Plugin (Creating a Custom Autocomplete Plugin)"} sample to see the working Autotag plugin created in this tutorial.
 
 ## Related Features
 

--- a/docs/features/autogrow/README.md
+++ b/docs/features/autogrow/README.md
@@ -65,7 +65,7 @@ With this setting in place, the 50-pixel-high space below the content will alway
 
 ## Auto Grow Demo
 
-See the {@linksdk autogrow working "Automatic Editor Height Adjustment to Content" sample} that shows how the editor can automatically expand and shrink vertically to fit the content.
+See the {@linkexample autogrow working "Automatic Editor Height Adjustment to Content" sample} that shows how the editor can automatically expand and shrink vertically to fit the content.
 
 ## Related Features
 

--- a/docs/features/balloontoolbar/README.md
+++ b/docs/features/balloontoolbar/README.md
@@ -66,4 +66,4 @@ It is possible to use low level API to control a Balloon Toolbar directly, in su
 
 ## Balloon Toolbar Demo
 
-See the {@linksdk balloontoolbar "Balloon Toolbar" sample} that shows an example of Balloon Toolbar usage.
+See the {@linkexample balloontoolbar "Balloon Toolbar" sample} that shows an example of Balloon Toolbar usage.

--- a/docs/features/basicstyles/README.md
+++ b/docs/features/basicstyles/README.md
@@ -119,7 +119,7 @@ Remember that depending on your use case, the CSS classes for basic text styles 
 
 ## Basic Text Styles Demo
 
-See the {@linksdk basicstyles working "Basic Text Styles: Bold, Italic and More" sample} that showcases the usage and customization of basic text formatting.
+See the {@linkexample basicstyles working "Basic Text Styles: Bold, Italic and More" sample} that showcases the usage and customization of basic text formatting.
 
 ## Related Features
 

--- a/docs/features/bbcode/README.md
+++ b/docs/features/bbcode/README.md
@@ -32,7 +32,7 @@ This feature is aimed at developers who would like to integrate CKEditor with po
 
 ## BBCode Output Demo
 
-See the {@linksdk bbcode working "BBCode Editing" sample} that showcases a CKEditor instance configured to output BBCode and customized to be a better fit for a typical BBCode environment.
+See the {@linkexample bbcode working "BBCode Editing" sample} that showcases a CKEditor instance configured to output BBCode and customized to be a better fit for a typical BBCode environment.
 
 ## Related Features
 

--- a/docs/features/codesnippet/README.md
+++ b/docs/features/codesnippet/README.md
@@ -36,7 +36,7 @@ If you use the {@link guide/dev/inline/README inline} or [div-based](https://cke
 ```
 
 <info-box hint="">
-    You can preview themes in the {@linksdk codesnippet "Inserting Code Snippets" sample}. You can also browse them on the <a href="https://highlightjs.org/static/demo/">highlight.js demo page</a>.
+    You can preview themes in the {@linkexample codesnippet "Inserting Code Snippets" sample}. You can also browse them on the <a href="https://highlightjs.org/static/demo/">highlight.js demo page</a>.
 </info-box>
 
 ### Target Page
@@ -70,7 +70,7 @@ In {@link guide/dev/framed/README classic editor} use the {@linkapi CKEDITOR.con
 
     config.codeSnippet_theme = 'school_book';
 
-For a complete list of available themes see the {@linksdk codesnippet Inserting Code Snippets sample} or the [highlight.js's demo page](https://highlightjs.org/static/demo/).
+For a complete list of available themes see the {@linkexample codesnippet Inserting Code Snippets sample} or the [highlight.js's demo page](https://highlightjs.org/static/demo/).
 
 {@img assets/img/codesnippet_05.png}
 
@@ -107,4 +107,4 @@ Since **Internet Explorer 8** support was dropped in [highlight.js](https://high
 
 ## Code Snippets Demo
 
-See the {@linksdk codesnippet working "Inserting Code Snippets" sample} that shows a few instances of the code snippet widgets as well as the syntax highlighter themes which are available in the default implementation.
+See the {@linkexample codesnippet working "Inserting Code Snippets" sample} that shows a few instances of the code snippet widgets as well as the syntax highlighter themes which are available in the default implementation.

--- a/docs/features/colorbutton/README.md
+++ b/docs/features/colorbutton/README.md
@@ -74,7 +74,7 @@ CKEditor will then output the color definition as `<font>` elements with `color`
 
 ## Text and Background Color Demo
 
-See the {@linksdk colorbutton working "Setting Text and Background Color" sample} that showcases the usage and customization of the text and background color features.
+See the {@linkexample colorbutton working "Setting Text and Background Color" sample} that showcases the usage and customization of the text and background color features.
 
 ## Related Features
 

--- a/docs/features/copyformatting/README.md
+++ b/docs/features/copyformatting/README.md
@@ -111,7 +111,7 @@ The special "disabled" cursor can be switched off by setting the {@linkapi CKEDI
 
 ## Copy Formatting Demo
 
-See the {@linksdk copyformatting working "Using the Copy Formatting Feature" sample} that showcases the usage and customization of this feature.
+See the {@linkexample copyformatting working "Using the Copy Formatting Feature" sample} that showcases the usage and customization of this feature.
 
 ## Related Features
 

--- a/docs/features/devtools/README.md
+++ b/docs/features/devtools/README.md
@@ -40,7 +40,7 @@ The Developer Tools plugin provides two configuration options:
 
 ## Developer Tools Demo
 
-See the {@linksdk devtools working "Developer Tools" sample} that showcases how easy it can be to get information about editor dialog windows and their elements.
+See the {@linkexample devtools working "Developer Tools" sample} that showcases how easy it can be to get information about editor dialog windows and their elements.
 
 ## Related Features
 

--- a/docs/features/drop_paste/README.md
+++ b/docs/features/drop_paste/README.md
@@ -34,7 +34,7 @@ Additionally, since CKEditor 4.5 it is possible to configure a {@link guide/dev/
 
 	config.pasteFilter = 'p; a[!href]';
 
-You can also read more about {@link guide/dev/acf/README content filtering} in general and see the {@linksdk acf working "Content Filtering" sample}.
+You can also read more about {@link guide/dev/acf/README content filtering} in general and see the {@linkexample acf working "Content Filtering" sample}.
 
 ## File Upload
 
@@ -50,9 +50,9 @@ Note that this feature is limited because of browsers and operating systems limi
 
 See the following samples for examples of pasting and dropping into editor content:
 
-* The {@linksdk fileupload#uploading-dropped-and-pasted-images "Uploading Dropped and Pasted Images"} sample.
-* The {@linksdk draganddrop "Drag and Drop Integration"} sample.
-* The {@linksdk pastefromword "Paste from Word"} sample.
+* The {@linkexample fileupload#uploading-dropped-and-pasted-images "Uploading Dropped and Pasted Images"} sample.
+* The {@linkexample draganddrop "Drag and Drop Integration"} sample.
+* The {@linkexample pastefromword "Paste from Word"} sample.
 
 ## Further Reading
 

--- a/docs/features/easyimage/README.md
+++ b/docs/features/easyimage/README.md
@@ -51,7 +51,7 @@ Easy Image allows for changing the default alternative text for the image. Provi
 
 ## Easy Image Demo
 
-See the {@linksdk easyimage working "Easy Image Plugin" sample} that showcases the Easy Image plugin with its uploading, captioning and custom styles.
+See the {@linkexample easyimage working "Easy Image Plugin" sample} that showcases the Easy Image plugin with its uploading, captioning and custom styles.
 
 ## Related Features
 

--- a/docs/features/embed/README.md
+++ b/docs/features/embed/README.md
@@ -66,7 +66,7 @@ If you wish to make it work with your custom media embed widget (see {@link feat
 
 	config.autoEmbed_widget = 'customEmbed';
 
-You can test auto embedding in the {@linksdk mediaembed Embedding Media Resources with oEmbed} sample.
+You can test auto embedding in the {@linkexample mediaembed Embedding Media Resources with oEmbed} sample.
 
 ## Implementing a New Embed Widget
 
@@ -74,4 +74,4 @@ Both plugins utilize the {@linkapi CKEDITOR.plugins.embedBase#createWidgetBaseDe
 
 ## Embedding Media Demo
 
-See the {@linksdk mediaembed working "Embedding Media Resources with oEmbed" sample} that showcases the Media Embed and Auto Embed plugins.
+See the {@linkexample mediaembed working "Embedding Media Resources with oEmbed" sample} that showcases the Media Embed and Auto Embed plugins.

--- a/docs/features/emoji/README.md
+++ b/docs/features/emoji/README.md
@@ -54,7 +54,7 @@ You can adjust the number of characters needed to show the emoji list when typin
 
 ## Emoji Demo
 
-See the {@linksdk mentions "Mentions, Tags and Emoji" sample} that shows an example of emoji used together with the mentions feature.
+See the {@linkexample mentions "Mentions, Tags and Emoji" sample} that shows an example of emoji used together with the mentions feature.
 
 ## Related Features
 

--- a/docs/features/enterkey/README.md
+++ b/docs/features/enterkey/README.md
@@ -38,4 +38,4 @@ Both configuration settings can use one of the following options:
 
 ## Enter Key Configuration Demo
 
-See the {@linksdk enterkey working "Enter Key Configuration" sample} that showcases the effects of using different settings for <kbd>Enter</kbd> and <kbd>Shift+Enter</kbd> keys on editor output.
+See the {@linkexample enterkey working "Enter Key Configuration" sample} that showcases the effects of using different settings for <kbd>Enter</kbd> and <kbd>Shift+Enter</kbd> keys on editor output.

--- a/docs/features/format/README.md
+++ b/docs/features/format/README.md
@@ -86,7 +86,7 @@ Remember that depending on your use case, the CSS classes for text formats need 
 
 ## Block-Level Text Formats Demo
 
-See the {@linksdk format working "Applying Block-Level Text Formats" sample} that showcases the usage and customization of basic text formatting.
+See the {@linkexample format working "Applying Block-Level Text Formats" sample} that showcases the usage and customization of basic text formatting.
 
 ## Related Features
 

--- a/docs/features/fullpage/README.md
+++ b/docs/features/fullpage/README.md
@@ -58,7 +58,7 @@ Additionally, you can use the optional [Document Properties](https://ckeditor.co
 
 ## Full Page Editing Demo
 
-See the {@linksdk fullpage working "Full Page Editing with Document Properties Plugin" sample} that showcases using CKEditor to work on a complete HTML page and to setup some document metadata.
+See the {@linkexample fullpage working "Full Page Editing with Document Properties Plugin" sample} that showcases using CKEditor to work on a complete HTML page and to setup some document metadata.
 
 ## Related Features
 

--- a/docs/features/image/README.md
+++ b/docs/features/image/README.md
@@ -42,7 +42,7 @@ Below you can see the plugin's Image Properties dialog window with the file brow
 
 ## Image Plugin Demo
 
-See the {@linksdk image working "Default Image Plugin" sample} that showcases the Image plugin with all its capabilities.
+See the {@linkexample image working "Default Image Plugin" sample} that showcases the Image plugin with all its capabilities.
 
 ## Related Features
 

--- a/docs/features/image2/README.md
+++ b/docs/features/image2/README.md
@@ -70,7 +70,7 @@ Do remember, though, that you need to define the CSS rules for these classes in 
 * For {@link guide/dev/framed/README classic editor} it can be done by defining additional styles in the stylesheets loaded by the editor. The same styles must be provided on the target page where the content will be loaded.
 * For {@link guide/dev/inline/README inline editor} the styles can be defined directly with `<style> ... <style>` or `<link href="..." rel="stylesheet">`, i.e. within the `<head>` section of the page.
 
-See the following {@linksdk styles#widget-styles showcase} of captioned image styling and alignment done through classes.
+See the following {@linkexample styles#widget-styles showcase} of captioned image styling and alignment done through classes.
 
 ## Making Alternative Text Mandatory
 
@@ -86,7 +86,7 @@ config.image2_altRequired = true;
 
 ## Enhanced Image Plugin Demo
 
-See the {@linksdk image2 working "Enhanced Image Plugin" sample} that showcases the Enhanced Image plugin with its captioning, "drag and drop" positioning, and "click and drag" resizing.
+See the {@linkexample image2 working "Enhanced Image Plugin" sample} that showcases the Enhanced Image plugin with its captioning, "drag and drop" positioning, and "click and drag" resizing.
 
 ## Related Features
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -12,7 +12,7 @@ For licensing, see LICENSE.md.
 
 # CKEditor Features Overview
 
-This section presents a whole variety of features that CKEditor has to offer. It is complemented by {@linksdk index **CKEditor Examples**}, an awesome collection of **working editor samples** that present all concepts discussed here and what is even more compelling, let you **download the source code** of each example with just one button click, ready to copy and paste into your own CKEditor implementation!
+This section presents a whole variety of features that CKEditor has to offer. It is complemented by {@linkexample index **CKEditor Examples**}, an awesome collection of **working editor samples** that present all concepts discussed here and what is even more compelling, let you **download the source code** of each example with just one button click, ready to copy and paste into your own CKEditor implementation!
 
 The Features Overview section is divided into two parts, **End-user Features** and **Integration Features**.
 

--- a/docs/features/magicline/README.md
+++ b/docs/features/magicline/README.md
@@ -69,4 +69,4 @@ The {@linkapi CKEDITOR.config.magicline_tabuList CKEDITOR.config.magicline_tabuL
 
 ## Magic Line Demo
 
-See the {@linksdk magicline working "Magic Line" sample} that showcases how Magic Line helps solve issues with cursor placement before or after elements such as nested tables, `<div>` elements, adjacent lists, or multiple horizontal rules.
+See the {@linkexample magicline working "Magic Line" sample} that showcases how Magic Line helps solve issues with cursor placement before or after elements such as nested tables, `<div>` elements, adjacent lists, or multiple horizontal rules.

--- a/docs/features/mathjax/README.md
+++ b/docs/features/mathjax/README.md
@@ -62,7 +62,7 @@ will turn all `<span class="equation">` elements into mathematical formulas widg
 
 ## Mathematical Formulas Demo
 
-See the {@linksdk mathjax working "Creating Mathematical Formulas with MathJax" sample} that showcases the Mathematical Formulas plugin with its MathJax widget that supports writing equations in TeX.
+See the {@linkexample mathjax working "Creating Mathematical Formulas with MathJax" sample} that showcases the Mathematical Formulas plugin with its MathJax widget that supports writing equations in TeX.
 
 ## Related Features
 

--- a/docs/features/mathtype/README.md
+++ b/docs/features/mathtype/README.md
@@ -151,7 +151,7 @@ In order to display mathematical formulas on the target page, i.e. the page wher
 
 ## Mathematical and Chemical Formulas Demo
 
-See the {@linksdk mathtype working "Creating Mathematical and Chemical Formulas with MathType" sample} that showcases the plugin.
+See the {@linkexample mathtype working "Creating Mathematical and Chemical Formulas with MathType" sample} that showcases the plugin.
 
 ## Related Features
 

--- a/docs/features/mentions/README.md
+++ b/docs/features/mentions/README.md
@@ -149,7 +149,7 @@ Throttling is configurable by using the {@linkapi CKEDITOR.plugins.mentions.conf
 
 ## Mentions Demo
 
-See the {@linksdk mentions working "Mentions, Tags and Emoji" sample} to check how mentions helps create a useful completion system for user name mentions and tags, saving your time and limiting the opportunity to make mistakes.
+See the {@linkexample mentions working "Mentions, Tags and Emoji" sample} to check how mentions helps create a useful completion system for user name mentions and tags, saving your time and limiting the opportunity to make mistakes.
 
 ## Related Features
 

--- a/docs/features/output_format/README.md
+++ b/docs/features/output_format/README.md
@@ -113,7 +113,7 @@ Numerous {@link guide/dev/configuration/README configuration options} let you tw
 
 ## HTML Output Formatting Demo
 
-See the {@linksdk htmlformatting working "HTML Output Formatting" sample} that showcases how to control HTML output produced by CKEditor.
+See the {@linkexample htmlformatting working "HTML Output Formatting" sample} that showcases how to control HTML output produced by CKEditor.
 
 ## Related Features
 

--- a/docs/features/pastefromexcel/README.md
+++ b/docs/features/pastefromexcel/README.md
@@ -46,7 +46,7 @@ will look like below after pasting to CKEditor with the [Paste from Word](https:
 
 ## Paste from Excel Demo
 
-See the {@linksdk pastefromexcel working "Pasting content from Microsoft Excel" sample} that showcases the using the Paste from Word plugin to paste Excel content.
+See the {@linkexample pastefromexcel working "Pasting content from Microsoft Excel" sample} that showcases the using the Paste from Word plugin to paste Excel content.
 
 ## Related Features
 

--- a/docs/features/pastefromgoogledocs/README.md
+++ b/docs/features/pastefromgoogledocs/README.md
@@ -70,7 +70,7 @@ HTML exposed by Google Docs does not comply to rules of valid and semantic HTML.
 
 ## Paste from Google Docs Demo
 
-See the {@linksdk pastefromgoogledocs working "Pasting content from Google Docs" sample} that showcases the Paste from Google Docs plugin.
+See the {@linkexample pastefromgoogledocs working "Pasting content from Google Docs" sample} that showcases the Paste from Google Docs plugin.
 
 ## Related Features
 

--- a/docs/features/pastefromlibreoffice/README.md
+++ b/docs/features/pastefromlibreoffice/README.md
@@ -70,7 +70,7 @@ HTML exposed by LibreOffice Writer does not fully comply to rules of valid and s
 
 ## Paste from LibreOffice Demo
 
-See the {@linksdk pastefromlibreoffice working "Pasting content from LibreOffice" sample} that showcases the Paste from LibreOffice plugin.
+See the {@linkexample pastefromlibreoffice working "Pasting content from LibreOffice" sample} that showcases the Paste from LibreOffice plugin.
 
 ## Related Features
 

--- a/docs/features/pastefromword/README.md
+++ b/docs/features/pastefromword/README.md
@@ -106,7 +106,7 @@ For CKEditor versions older than 4.6 the following options were available, too:
 
 ## Paste from Word Demo
 
-See the {@linksdk pastefromword working "Pasting content from Microsoft Word" sample} that showcases the Paste from Word plugin.
+See the {@linkexample pastefromword working "Pasting content from Microsoft Word" sample} that showcases the Paste from Word plugin.
 
 ## Related Features
 

--- a/docs/features/placeholder/README.md
+++ b/docs/features/placeholder/README.md
@@ -28,7 +28,7 @@ Please note that the default placeholder implementation might easily be extended
 
 ## Placeholder Demo
 
-See the {@linksdk placeholder working "Using Placeholders" sample} that showcases a possible use for the Placeholder plugin in automatic replies sent from a Customer Support system.
+See the {@linkexample placeholder working "Using Placeholders" sample} that showcases a possible use for the Placeholder plugin in automatic replies sent from a Customer Support system.
 
 ## Related Features
 

--- a/docs/features/readonly/README.md
+++ b/docs/features/readonly/README.md
@@ -32,4 +32,4 @@ The same can be achieved by setting the `disabled` attribute for the `<textarea>
 
 ## Read-Only Mode Demo
 
-See also the {@linksdk readonly working "Read-Only Mode" sample} that showcases toggling between the read-only and editable mode.
+See also the {@linkexample readonly working "Read-Only Mode" sample} that showcases toggling between the read-only and editable mode.

--- a/docs/features/removeformat/README.md
+++ b/docs/features/removeformat/README.md
@@ -30,7 +30,7 @@ The second image presents the same text after the formatting cleanup done throug
 
 ## Removing Text Formatting Demo
 
-See the {@linksdk removeformat working "Removing Text Formatting" sample} that showcases the usage of the inline formatting cleanup functionality.
+See the {@linkexample removeformat working "Removing Text Formatting" sample} that showcases the usage of the inline formatting cleanup functionality.
 
 ## Related Features
 

--- a/docs/features/resize/README.md
+++ b/docs/features/resize/README.md
@@ -90,7 +90,7 @@ If you want to allow both vertical and horizontal resizing, you need to set the 
 
 ## Editor Resizing Customization Demo
 
-See the {@linksdk resize working "Editor Resizing Customization" sample} that showcases an editor instance with modified resizing settings.
+See the {@linkexample resize working "Editor Resizing Customization" sample} that showcases an editor instance with modified resizing settings.
 
 ## Related Features
 

--- a/docs/features/sharedspace/README.md
+++ b/docs/features/sharedspace/README.md
@@ -64,7 +64,7 @@ config.removePlugins = 'resize';
 
 ## Shared Toolbar and Bottom Bar Demo
 
-See the {@linksdk sharedspace working "Shared Toolbar and Bottom Bar" sample} that showcases how multiple editor instances can share the same toolbar and bottom bar.
+See the {@linkexample sharedspace working "Shared Toolbar and Bottom Bar" sample} that showcases how multiple editor instances can share the same toolbar and bottom bar.
 
 ## Related Features
 

--- a/docs/features/shortcuts/README.md
+++ b/docs/features/shortcuts/README.md
@@ -124,7 +124,7 @@ Please refer to the {@link features/accessibility_checker/README#keyboard-shortc
 
 ## Accessibility and Keyboard Shortcuts Demo
 
-See the {@linksdk accessibility working "Accessibility Support and Keyboard Shortcuts" sample} that showcases the usage of some accessibility-related features.
+See the {@linkexample accessibility working "Accessibility Support and Keyboard Shortcuts" sample} that showcases the usage of some accessibility-related features.
 
 ## Related Features
 

--- a/docs/features/size/README.md
+++ b/docs/features/size/README.md
@@ -55,7 +55,7 @@ Additionally, the [Editor Resize](https://ckeditor.com/cke4/addon/resize) plugin
 
 ## Editor Size Demo
 
-See the {@linksdk size working "Setting Editor Size" sample} that showcases an editor instance with modified dimensions.
+See the {@linkexample size working "Setting Editor Size" sample} that showcases an editor instance with modified dimensions.
 
 ## Related Features
 

--- a/docs/features/sourcearea/README.md
+++ b/docs/features/sourcearea/README.md
@@ -68,7 +68,7 @@ Please note this is an experimental CSS property which may not be supported in a
 
 ## Source Code Editing Demo
 
-See the {@linksdk sourcearea working "Source Code Editing" sample} that showcases both source editing plugins combined with classic and inline editor instances.
+See the {@linkexample sourcearea working "Source Code Editing" sample} that showcases both source editing plugins combined with classic and inline editor instances.
 
 ## Related Features
 

--- a/docs/features/spellcheck/README.md
+++ b/docs/features/spellcheck/README.md
@@ -104,4 +104,4 @@ You can find them on the {@linkapi CKEDITOR.config `CKEDITOR.config`} API page, 
 
 ## Spell Checking Demo
 
-See the {@linksdk spellchecker working "Proofreading, Spelling and Grammar Checking" sample} that showcases all three official spell and grammar checking solutions.
+See the {@linkexample spellchecker working "Proofreading, Spelling and Grammar Checking" sample} that showcases all three official spell and grammar checking solutions.

--- a/docs/features/spreadsheets/README.md
+++ b/docs/features/spreadsheets/README.md
@@ -61,13 +61,13 @@ Each suggestion consists of six parts. For example, a suggestion like <span styl
 	<li>The row name (<span style="color:hsl(214, 93%, 41%);">11</span>) &ndash; Filters suggestions by row names.</li>
 </ol>
 
-You can try out this feature in the {@linksdk spreadsheets#cell-referencing dedicated sample}.
+You can try out this feature in the {@linkexample spreadsheets#cell-referencing dedicated sample}.
 
 ## Conditional Formatting
 
 Do you need to add some colors to your data? Conditional formatting allows formatting data (any cell, column or entire data grid) based on its content. For example, you can mark cells red when they are empty, make them green when their value is above some threshold or blue if the cell value contains a specific text.
 
-Conditional formatting comes with a dozen of predefined rules. Any number of rules can be set up for each cell, which allows for complex formatting and handling advanced cases. You can even drag and drop conditional formatting rules, changing their priority to easily create features like a color scale. Put your hands on the color scale example in the {@linksdk spreadsheets working Spreadsheets demo}.
+Conditional formatting comes with a dozen of predefined rules. Any number of rules can be set up for each cell, which allows for complex formatting and handling advanced cases. You can even drag and drop conditional formatting rules, changing their priority to easily create features like a color scale. Put your hands on the color scale example in the {@linkexample spreadsheets working Spreadsheets demo}.
 
 {@img assets/img/spreadsheet_10.png Spreadsheet plugin with the Conditional Formatting dialog.}
 
@@ -182,7 +182,7 @@ One of the main features of a WYSIWYG editor is the ability to show the created 
 
 ## Spreadsheets Demo
 
-See the {@linksdk spreadsheets working "Creating Data Grids with Spreadsheet Plugin" sample} that showcases the most important features like data styling, sorting, conditional formatting, formulas and more.
+See the {@linkexample spreadsheets working "Creating Data Grids with Spreadsheet Plugin" sample} that showcases the most important features like data styling, sorting, conditional formatting, formulas and more.
 
 ## Related Features
 

--- a/docs/features/styles/README.md
+++ b/docs/features/styles/README.md
@@ -121,7 +121,7 @@ Sample widget styles:
 { name: 'thumb', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-thumb' }, group: [ 'size', 'alignment' ] }
 ```
 
-To see how this works in practice, refer to the {@linksdk styles#widget-styles Widget Styles} sample. It contains a working editor instance that includes the {@link features/image2/README enhanced image}, {@link features/embed/README embedded media resources} and {@link features/mathjax/README mathematical formulas} widgets with additional styling.
+To see how this works in practice, refer to the {@linkexample styles#widget-styles Widget Styles} sample. It contains a working editor instance that includes the {@link features/image2/README enhanced image}, {@link features/embed/README embedded media resources} and {@link features/mathjax/README mathematical formulas} widgets with additional styling.
 
 ## The Stylesheet Parser Plugin
 
@@ -168,7 +168,7 @@ config.stylesheetParser_skipSelectors = /(^body\.|^caption\.|\.high|^\.)/i;
 
 ## Editor Styles Demo
 
-See the {@linksdk styles working "Applying Styles to Editor Content" sample} that showcases the use of default editor styles as well as a Stylesheet Parser plugin implementation.
+See the {@linkexample styles working "Applying Styles to Editor Content" sample} that showcases the use of default editor styles as well as a Stylesheet Parser plugin implementation.
 
 ## Related Features
 

--- a/docs/features/tabindex/README.md
+++ b/docs/features/tabindex/README.md
@@ -30,7 +30,7 @@ This will cause CKEditor to become the third page element that you will enter wh
 
 ## "Tab" Key Based Navigation Demo
 
-See the {@linksdk tabindex working "Page Navigation Using the "Tab" Key" sample} where you can try this page navigation method in practice.
+See the {@linkexample tabindex working "Page Navigation Using the "Tab" Key" sample} where you can try this page navigation method in practice.
 
 ## Related Features
 

--- a/docs/features/table/README.md
+++ b/docs/features/table/README.md
@@ -60,7 +60,7 @@ You need to hover your mouse over the column border to see the cursor change to 
 
 ## Table Support Demo
 
-See the {@linksdk table working "Table Support with Column Resizing" sample} that showcases CKEditor support for creating and editing tables, including table column resizing with your mouse.
+See the {@linkexample table working "Table Support with Column Resizing" sample} that showcases CKEditor support for creating and editing tables, including table column resizing with your mouse.
 
 ## Related Features
 

--- a/docs/features/toolbar/README.md
+++ b/docs/features/toolbar/README.md
@@ -65,7 +65,7 @@ When you are happy with your toolbar, copy the modified toolbar configuration fr
 
 ## Custom Toolbar Demo
 
-See the {@linksdk toolbar working "Custom Editor Toolbar" sample} that showcases an editor instance with a one-row toolbar set to include just a few most relevant editing features.
+See the {@linkexample toolbar working "Custom Editor Toolbar" sample} that showcases an editor instance with a one-row toolbar set to include just a few most relevant editing features.
 
 ## Related Features
 

--- a/docs/features/toolbarconcepts/README.md
+++ b/docs/features/toolbarconcepts/README.md
@@ -107,7 +107,7 @@ Screen readers will announce each of the toolbar groups by using either their re
 
 ## Custom Toolbar Demo
 
-See the {@linksdk toolbar working "Custom Editor Toolbar" sample} that showcases an editor instance with a one-row toolbar set to include just a few most relevant editing features.
+See the {@linkexample toolbar working "Custom Editor Toolbar" sample} that showcases an editor instance with a one-row toolbar set to include just a few most relevant editing features.
 
 ## Related Features
 

--- a/docs/features/toolbarlocation/README.md
+++ b/docs/features/toolbarlocation/README.md
@@ -28,7 +28,7 @@ Please note that this option is only applicable to {@link guide/dev/framed/READM
 
 ## Toolbar Location Demo
 
-See the {@linksdk toolbarlocation working "Toolbar Location Adjustment" sample} that showcases how to place the editor toolbar at the bottom of its interface.
+See the {@linkexample toolbarlocation working "Toolbar Location Adjustment" sample} that showcases how to place the editor toolbar at the bottom of its interface.
 
 ## Related Features
 

--- a/docs/features/uicolor/README.md
+++ b/docs/features/uicolor/README.md
@@ -31,7 +31,7 @@ This will cause the editor UI to assume the provided color, as visible below.
 
 ## User Interface Color Demo
 
-The {@linksdk uicolor "Setting Editor UI Color" sample} shows how the editor user interface color can be changed by using the configuration option.
+The {@linkexample uicolor "Setting Editor UI Color" sample} shows how the editor user interface color can be changed by using the configuration option.
 
 ## Related Features
 

--- a/docs/features/uicolorpicker/README.md
+++ b/docs/features/uicolorpicker/README.md
@@ -41,7 +41,7 @@ Although this feature is mainly useful for developers who are working on their C
 
 ## UI Color Picker Demo
 
-See the {@linksdk uicolorpicker working "UI Color Picker" sample} that showcases how easy it can be to set the editor UI color with the color picker tool.
+See the {@linkexample uicolorpicker working "UI Color Picker" sample} that showcases how easy it can be to set the editor UI color with the color picker tool.
 
 ## Related Features
 

--- a/docs/features/uilanguage/README.md
+++ b/docs/features/uilanguage/README.md
@@ -48,4 +48,4 @@ This will cause CKEditor interface to be displayed in German to all users, overr
 
 ## UI Languages Demo
 
-See also the {@linksdk uilanguages working "Setting Editor UI Language" sample} that showcases all available CKEditor user interface localizations and includes a simple script that lets the user choose a different language version.
+See also the {@linkexample uilanguages working "Setting Editor UI Language" sample} that showcases all available CKEditor user interface localizations and includes a simple script that lets the user choose a different language version.

--- a/docs/features/uitypes/README.md
+++ b/docs/features/uitypes/README.md
@@ -73,8 +73,8 @@ Due to the dynamic nature of floating UI, **some editor features are unavailable
 
 The following samples are available for two CKEditor user interface types:
 
-* The {@linksdk fixedui Fixed User Interface} sample shows the implementation of fixed UI with both classic and inline editor.
-* The {@linksdk floatingui Floating User Interface} sample shows an inline editor instance with its default floating UI.
+* The {@linkexample fixedui Fixed User Interface} sample shows the implementation of fixed UI with both classic and inline editor.
+* The {@linkexample floatingui Floating User Interface} sample shows an inline editor instance with its default floating UI.
 
 ## Related Features
 

--- a/docs/guide/dev/a11y/README.md
+++ b/docs/guide/dev/a11y/README.md
@@ -52,7 +52,7 @@ The following features will make it possible for people with special needs to us
 
 ## Accessibility Features Overview
 
-The following section describes some of the most important accessibility-related features that are available in CKEditor. You can try them out on the {@linksdk accessibility working "Accessibility Support and Keyboard Shortcuts" sample} or any other applicable demos listed below.
+The following section describes some of the most important accessibility-related features that are available in CKEditor. You can try them out on the {@linkexample accessibility working "Accessibility Support and Keyboard Shortcuts" sample} or any other applicable demos listed below.
 
 ### Keyboard Access
 
@@ -60,7 +60,7 @@ The following features make working with CKEditor through standard keyboard easy
 
 #### Reaching the Editor on the Page
 
-CKEditor takes part in the <kbd>Tab</kbd> order of a web page that it is embedded in. It can be reached and exited by using the <kbd>Tab</kbd> and <kbd>Shift+Tab</kbd> keyboard shortcuts that are commonly used for navigating between page elements. Read more {@link features/tabindex/README here} and see the {@linksdk tabindex working demo} here.
+CKEditor takes part in the <kbd>Tab</kbd> order of a web page that it is embedded in. It can be reached and exited by using the <kbd>Tab</kbd> and <kbd>Shift+Tab</kbd> keyboard shortcuts that are commonly used for navigating between page elements. Read more {@link features/tabindex/README here} and see the {@linkexample tabindex working demo} here.
 
 #### Keyboard Navigation
 
@@ -76,7 +76,7 @@ Additionally, for CKEditor 4.6 and later, all keyboard shortcuts available for a
 
 {@img assets/img/keyboardshortcuts_01.png Keyboard shortcuts visible in the editor context menu}
 
-You can also try out the {@linksdk accessibility working demo}. The editor usage through the keyboard is most intuitive and as straightforward as possible.
+You can also try out the {@linkexample accessibility working demo}. The editor usage through the keyboard is most intuitive and as straightforward as possible.
 
 ### Assistive Technology Support
 
@@ -136,18 +136,18 @@ The following features can be used by developers to ensure that content created 
 
 #### Accessibility Checker
 
-The innovative {@link features/accessibility_checker/README Accessibility Checker} tool lets you inspect the accessibility level of content created in the editor and fix reported issues, often fully automatically. It is a **must-have addon** for government institutions and companies that are often required by law to ensure the content they produce meets accessibility standards. See the {@linksdk accessibilitychecker working demo} and get the plugin [here](https://ckeditor.com/cke4/addon/a11ychecker).
+The innovative {@link features/accessibility_checker/README Accessibility Checker} tool lets you inspect the accessibility level of content created in the editor and fix reported issues, often fully automatically. It is a **must-have addon** for government institutions and companies that are often required by law to ensure the content they produce meets accessibility standards. See the {@linkexample accessibilitychecker working demo} and get the plugin [here](https://ckeditor.com/cke4/addon/a11ychecker).
 
 #### Setting Language of Parts for Editor Content
 
-The optional Language plugin, introduced in CKEditor 4.3, implements the [WCAG 3.1.2 Language of Parts](http://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-other-lang-id.html) specification. It lets you assign one of the pre-configured languages to a text selection. See the {@linksdk language working demo} and get the plugin [here](https://ckeditor.com/cke4/addon/language).
+The optional Language plugin, introduced in CKEditor 4.3, implements the [WCAG 3.1.2 Language of Parts](http://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-other-lang-id.html) specification. It lets you assign one of the pre-configured languages to a text selection. See the {@linkexample language working demo} and get the plugin [here](https://ckeditor.com/cke4/addon/language).
 
 ## Accessibility Features Demos
 
 See the following working samples to check some accessibility-related features of CKEditor:
 
-* The {@linksdk accessibility "Accessibility Support and Keyboard Shortcuts" sample} showcases such features as the Accessibility Help dialog or the usage of keyboard shortcuts.
-* The {@linksdk accessibilitychecker "Accessibility Checker" sample} shows how to detect and fix accessibility issues in your editor content.
+* The {@linkexample accessibility "Accessibility Support and Keyboard Shortcuts" sample} showcases such features as the Accessibility Help dialog or the usage of keyboard shortcuts.
+* The {@linkexample accessibilitychecker "Accessibility Checker" sample} shows how to detect and fix accessibility issues in your editor content.
 
 ## Related Features
 

--- a/docs/guide/dev/acf/README.md
+++ b/docs/guide/dev/acf/README.md
@@ -146,8 +146,8 @@ Bold text can be represented on websites by `<strong>`, `<b>`, or `<span style="
 
 The following samples are available for two ACF modes:
 
-* The {@linksdk acf Advanced Content Filter &ndash; Automatic Mode} sample shows the default implementation of ACF and its customization.
-* The {@linksdk acfcustom Advanced Content Filter &ndash; Custom Mode} sample shows how the custom ACF mode works.
+* The {@linkexample acf Advanced Content Filter &ndash; Automatic Mode} sample shows the default implementation of ACF and its customization.
+* The {@linkexample acfcustom Advanced Content Filter &ndash; Custom Mode} sample shows how the custom ACF mode works.
 
 ## Further Reading
 

--- a/docs/guide/dev/basics/README.md
+++ b/docs/guide/dev/basics/README.md
@@ -50,7 +50,7 @@ There are a few scenarios where CKEditor seems to be just the tool that you need
 
 * CKEditor is not a tool that will let you input invalid HTML code. CKEditor abides by W3C standards so it will modify code if it is invalid.
 
-At the end of the day, **CKEditor is an editor &mdash; nothing more, nothing less**. Go to the {@linksdk index CKEditor Examples} section to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
+At the end of the day, **CKEditor is an editor &mdash; nothing more, nothing less**. Go to the {@linkexample index CKEditor Examples} section to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
 
 ## How CKEditor Works
 

--- a/docs/guide/dev/best_practices/README.md
+++ b/docs/guide/dev/best_practices/README.md
@@ -81,7 +81,7 @@ or, if you are using the HTML5 `DOCTYPE`, to:
 ```
 
 ### Use CKEditor for what it was made for
-Last but not least, {@link guide/dev/basics/README#what-ckeditor-is use CKEditor for what it was designed for}. Learn from the best: Visit the {@linksdk index CKEditor Examples} to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
+Last but not least, {@link guide/dev/basics/README#what-ckeditor-is use CKEditor for what it was designed for}. Learn from the best: Visit the {@linkexample index CKEditor Examples} to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
 
 ## Security
 

--- a/docs/guide/dev/ckeditor_js_load/README.md
+++ b/docs/guide/dev/ckeditor_js_load/README.md
@@ -32,13 +32,13 @@ Now that the CKEditor JavaScript API is available on the page, you can use it to
 ### Classic Editing
 {@link guide/dev/framed/README Classic editing} is the most common way to use CKEditor, when the editor is usually represented by a toolbar and an editing area placed in a specific position on the page. Sometimes it is also called "framed editing", because in this scenario the editor creates a temporary `<iframe>` element for itself.
 
-{@linksdk classic See the demo here}. Read all about this editor type in the {@link guide/dev/framed/README Classic Editing} article.
+{@linkexample classic See the demo here}. Read all about this editor type in the {@link guide/dev/framed/README Classic Editing} article.
 
 {@img assets/img/classic_example.png Classic editor example}
 
 ### Inline Editing
 {@link guide/dev/inline/README Inline editing} is an innovative feature that can be used for content which needs to look like the final page, giving you a true <abbr title="What You See Is What You Get">WYSIWYG</abbr> experience. Editing is enabled directly on HTML elements through the HTML5 `contenteditable` attribute. The editor toolbar appears automatically for these elements, floating on the page.
 
-{@linksdk inline See the demo here}. Read all about this editor type in the {@link guide/dev/inline/README Inline Editing} article.
+{@linkexample inline See the demo here}. Read all about this editor type in the {@link guide/dev/inline/README Inline Editing} article.
 
 {@img assets/img/inline_example.png Inline editor example}

--- a/docs/guide/dev/configuration/README.md
+++ b/docs/guide/dev/configuration/README.md
@@ -85,4 +85,4 @@ This setting is definitely recommended, if you are not setting the configuration
 
 If you are wondering what CKEditor features are available, head to the {@link features/index Features Overview} section. You will find a many editor features categorized and explained there, along with references to configuration options that let you customize them.
 
-The Features Overview section is complemented by {@linksdk index CKEditor Examples}, an awesome collection of **working editor samples** that present all concepts discussed there and what is even more compelling, let you **download the source code** of each example with just one button click, ready to copy and paste into your own CKEditor implementation!
+The Features Overview section is complemented by {@linkexample index CKEditor Examples}, an awesome collection of **working editor samples** that present all concepts discussed there and what is even more compelling, let you **download the source code** of each example with just one button click, ready to copy and paste into your own CKEditor implementation!

--- a/docs/guide/dev/deep_dive/advanced_content_filter/README.md
+++ b/docs/guide/dev/deep_dive/advanced_content_filter/README.md
@@ -43,7 +43,7 @@ In both modes it is possible to extend the filter configuration by using the {@l
 
 Advanced Content Filter works in automatic mode when the {@linkapi CKEDITOR.config#allowedContent} setting is not provided. During the editor initialization, the editor features add their rules to the filter. As a result, only the content that may be edited using the currently loaded features is allowed, and all the rest is filtered out.
 
-Please note that this means that **ACF is tightly connected with the editor configuration**. Take the official CKEditor presets (Basic, Standard and Full). Each one of them includes a different set of features (toolbar buttons, keyboard shortcuts, content styles) and as a result, the same content pasted into editor instances with these configurations {@linksdk acf will look completely different}, as CKEditor will adjust it to what is available in a particular setup.
+Please note that this means that **ACF is tightly connected with the editor configuration**. Take the official CKEditor presets (Basic, Standard and Full). Each one of them includes a different set of features (toolbar buttons, keyboard shortcuts, content styles) and as a result, the same content pasted into editor instances with these configurations {@linkexample acf will look completely different}, as CKEditor will adjust it to what is available in a particular setup.
 
 Whenever you adjust your editor configuration, for example by using the {@linkapi CKEDITOR.config.removePlugins} and {@linkapi CKEDITOR.config.removeButtons} methods or customizing the **Format** and **Styles** drop-down lists, these changes will affect the filter and the automatic ACF mode will make the editor remove content corresponding to disabled features.
 
@@ -59,7 +59,7 @@ config.format_tags = 'p;h1;h2;pre';
 
 In this setup several tags will not be allowed in the editor because there is no plugin or button that is responsible for creating and editing this kind of content. This pertains to elements such as `<img>` (Image feature), `<table>` and its descendants (Table and Table Tools plugins) and `<hr>` (Horizontal Rule feature) as well as `<u>`, `<s>`, `<sub>` and `<sup>` that are normally provided by the Basic Styles plugin, but whose buttons were removed in the configuration. The **Format** drop-down list was trimmed down, too, so unsupported formats will also be removed.
 
-See the {@linksdk acf Advanced Content Filter &ndash; Automatic Mode} sample for a live demonstration.
+See the {@linkexample acf Advanced Content Filter &ndash; Automatic Mode} sample for a live demonstration.
 
 <info-box hint="">
 	If you want to configure the editor to work in automatic mode, but need to enable additional HTML tags, attributes, styles, or classes, use the {@linkapi CKEDITOR.config#extraAllowedContent} configuration option. <strong>Since CKEditor 4.4</strong> you can also disallow some of the automatically allowed content by using the {@linkapi CKEDITOR.config#disallowedContent} option.
@@ -92,7 +92,7 @@ This will have the following effect:
 * `img(left,right)[!src,alt,width,height]` &ndash; The `src` attribute is obligatory for the `<img>` tag. The `alt`, `width`, `height` and `class` attributes are accepted, but `class` must be either `class="left"` or `class="right"`.
 * Several toolbar buttons and dialog window fields that are responsible for the features which were not explicitly listed as allowed will be removed. In the Standard editor preset this will mean that, for example, the Strike-through, Numbered List, Bulleted List, Anchor, Table and Horizontal Line toolbar buttons will be gone, just like most of the fields of the Image Properties dialog window and formats from the Format drop-down list.
 
-See the {@linksdk acfcustom Advanced Content Filter &ndash; Custom Mode} sample for a live demonstration.
+See the {@linkexample acfcustom Advanced Content Filter &ndash; Custom Mode} sample for a live demonstration.
 
 ## Content Transformations
 
@@ -142,8 +142,8 @@ Using the above rule with the {@linkapi CKEDITOR.config#disallowedContent} setti
 
 The following samples are available for two ACF modes:
 
-* The {@linksdk acf Advanced Content Filter &ndash; Automatic Mode} sample shows the default implementation of ACF and its customization.
-* The {@linksdk acfcustom Advanced Content Filter &ndash; Custom Mode} sample shows how the custom ACF mode works.
+* The {@linkexample acf Advanced Content Filter &ndash; Automatic Mode} sample shows the default implementation of ACF and its customization.
+* The {@linkexample acfcustom Advanced Content Filter &ndash; Custom Mode} sample shows how the custom ACF mode works.
 
 ## Further Reading
 

--- a/docs/guide/dev/deep_dive/clipboard/README.md
+++ b/docs/guide/dev/deep_dive/clipboard/README.md
@@ -189,7 +189,7 @@ editor.on( 'dragstart', function( evt ) {
 
 As you can see, when the user drags a widget, its ID is stored in the data under the `cke/widget-id` type. This allows you to find and handle that specific widget instance on {@linkapi CKEDITOR.editor#drop drop}.
 
-Another example can be found in the {@linksdk draganddrop "Drag and Drop Integration" sample} where the  {@linkapi CKEDITOR.plugins.clipboard.dataTransfer `dataTransfer` facade} is used to store an object with contact details that are dragged into the editor from outside of it.
+Another example can be found in the {@linkexample draganddrop "Drag and Drop Integration" sample} where the  {@linkapi CKEDITOR.plugins.clipboard.dataTransfer `dataTransfer` facade} is used to store an object with contact details that are dragged into the editor from outside of it.
 
 ```js
 // When an item in the contact list is dragged, copy its data into drag and drop data transfer.

--- a/docs/guide/dev/example_setups/README.md
+++ b/docs/guide/dev/example_setups/README.md
@@ -75,7 +75,7 @@ Inline editor provides a real WYSIWYG experience "out of the box" because unlike
 This demo showcases the <strong>Accessibility Checker</strong> plugin &mdash; an innovative solution that lets you inspect the accessibility level of content created in CKEditor and immediately solve any accessibility issues that are found.
 
 <info-box hint="">
-  Visit the {@linksdk accessibilitychecker CKEditor Examples} website to try out this configuration.
+  Visit the {@linkexample accessibilitychecker CKEditor Examples} website to try out this configuration.
 </info-box>
 
 <div class="responsive">

--- a/docs/guide/dev/framed/README.md
+++ b/docs/guide/dev/framed/README.md
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md.
 
 Classic editing is still probably the most common way to use CKEditor. In this usage scenario the editor is most often represented by a toolbar and an editing area placed in a specific position on the page, usually as a part of a form that you use to submit some content to the server. Sometimes it is also called "framed editing", because in this case the editor creates a temporary `<iframe>` element for itself.
 
-This method is used in the {@link guide/dev/installation/README#adding-ckeditor-to-your-page Quick Start Guide} example. To try it out, see also the {@linksdk classic classic editing demo}.
+This method is used in the {@link guide/dev/installation/README#adding-ckeditor-to-your-page Quick Start Guide} example. To try it out, see also the {@linkexample classic classic editing demo}.
 
 <img src="%BASE_PATH%/assets/img/classic_example.png" alt="Classic editor example">
 
@@ -95,7 +95,7 @@ To insert a CKEditor instance, you can use the following sample that creates a b
 
 ## Classic Editing Demo
 
-See the {@linksdk classic working "Classic Editor" sample} that showcases a few usage scenarios for classic editing.
+See the {@linkexample classic working "Classic Editor" sample} that showcases a few usage scenarios for classic editing.
 
 ## Further Reading
 

--- a/docs/guide/dev/howtos/basic_configuration/README.md
+++ b/docs/guide/dev/howtos/basic_configuration/README.md
@@ -44,9 +44,9 @@ Do remember to use the [online builder](https://ckeditor.com/cke4/builder) to do
 
 ## How Do I Find Code Examples Showing CKEditor Customization?
 
-{@linksdk index CKEditor Examples} was created to present a broad range of existing features, usage scenarios and customization options for CKEditor. Each SDK sample contains a short description and references as well as one or more CKEditor instances to play with. Scroll down to the "Get Sample Source Code" of each sample to view the source code ready to copy and implement in your own solution.
+{@linkexample index CKEditor Examples} was created to present a broad range of existing features, usage scenarios and customization options for CKEditor. Each SDK sample contains a short description and references as well as one or more CKEditor instances to play with. Scroll down to the "Get Sample Source Code" of each sample to view the source code ready to copy and implement in your own solution.
 
-The figure below presents one of the CKEditor samples, {@linksdk mathjax Creating Mathematical Formulas}, opened in a browser.
+The figure below presents one of the CKEditor samples, {@linkexample mathjax Creating Mathematical Formulas}, opened in a browser.
 
 <img src="%BASE_PATH%/assets/img/ckeditor-SDK-sample.png" width="918" height="763" alt="One of the CKEditor samples as viewed in Firefox">
 

--- a/docs/guide/dev/howtos/basic_configuration/README.md
+++ b/docs/guide/dev/howtos/basic_configuration/README.md
@@ -44,7 +44,7 @@ Do remember to use the [online builder](https://ckeditor.com/cke4/builder) to do
 
 ## How Do I Find Code Examples Showing CKEditor Customization?
 
-{@linkexample index CKEditor Examples} was created to present a broad range of existing features, usage scenarios and customization options for CKEditor. Each SDK sample contains a short description and references as well as one or more CKEditor instances to play with. Scroll down to the "Get Sample Source Code" of each sample to view the source code ready to copy and implement in your own solution.
+{@linkexample index CKEditor Examples} was created to present a broad range of existing features, usage scenarios and customization options for CKEditor. Each example contains a short description and references as well as one or more CKEditor instances to play with. Scroll down to the "Get Sample Source Code" of each sample to view the source code ready to copy and implement in your own solution.
 
 The figure below presents one of the CKEditor samples, {@linkexample mathjax Creating Mathematical Formulas}, opened in a browser.
 

--- a/docs/guide/dev/howtos/dialog_windows/README.md
+++ b/docs/guide/dev/howtos/dialog_windows/README.md
@@ -101,7 +101,7 @@ If, for example, you want to open the **Upload** tab first to make it more conve
 
 ## How Do I Learn the Names of CKEditor Dialog Window Fields?
 
-If you want to customize a dialog window, the easiest and most convenient way is to enable the {@link features/devtools/README Developer Tools} plugin that displays the names and IDs of all dialog window elements when you hover them with your mouse. You can see the plugin demo in {@linksdk devtools CKEditor Examples}.
+If you want to customize a dialog window, the easiest and most convenient way is to enable the {@link features/devtools/README Developer Tools} plugin that displays the names and IDs of all dialog window elements when you hover them with your mouse. You can see the plugin demo in {@linkexample devtools CKEditor Examples}.
 
 The following figure shows the tooltip that describes the **URL** field of the **Link** dialog window that is displayed after the **Developer Tools** plugin was enabled.
 

--- a/docs/guide/dev/howtos/interface/README.md
+++ b/docs/guide/dev/howtos/interface/README.md
@@ -69,7 +69,7 @@ Since version 4.5 each CKEditor installation package includes a handy tool calle
 
 The {@link guide/dev/a11y/README Accessibility Support in CKEditor} contains lots of useful information on using the CKEditor interface with your keyboard or with assistive devices such as screen readers.
 
-CKEditor takes part in the <kbd>Tab</kbd> order of a web page that it is embedded in. Read more {@link features/tabindex/README here} and see the {@linksdk tabindex working demo} here.
+CKEditor takes part in the <kbd>Tab</kbd> order of a web page that it is embedded in. Read more {@link features/tabindex/README here} and see the {@linkexample tabindex working demo} here.
 
 Many functions in CKEditor have their equivalent keyboard shortcuts. This is one of the reasons why working with the editor is simple and efficient.
 

--- a/docs/guide/dev/howtos/output/README.md
+++ b/docs/guide/dev/howtos/output/README.md
@@ -19,7 +19,7 @@ The following article contains tips about customizing the output HTML code produ
 
 If you want CKEditor to output valid HTML4 code instead of XHTML, you should configure the behavior of the {@linkapi CKEDITOR.dataProcessor dataProcessor}.
 
-For some tips on how to achieve this, check the {@link features/output_format/README HTML Output Formatting} article as well as the {@linksdk htmlformatting HTML Output Formatting} sample in CKEditor Examples.
+For some tips on how to achieve this, check the {@link features/output_format/README HTML Output Formatting} article as well as the {@linkexample htmlformatting HTML Output Formatting} sample in CKEditor Examples.
 
 If, for example, you want CKEditor to output the self-closing tags in the HTML4 way, creating `<br>` elements instead of `<br/>`, configure the `selfClosingEnd` setting in the following way.
 
@@ -29,6 +29,6 @@ If, for example, you want CKEditor to output the self-closing tags in the HTML4 
 
 ## How Do I Output BBCode Instead of HTML Code Using CKEditor?
 
-You should try the [BBCode plugin](https://ckeditor.com/cke4/addon/bbcode). See the {@linksdk bbcode BBCode Editing sample} and the {@link features/bbcode/README documentation} for more information.
+You should try the [BBCode plugin](https://ckeditor.com/cke4/addon/bbcode). See the {@linkexample bbcode BBCode Editing sample} and the {@link features/bbcode/README documentation} for more information.
 
 <img src="%BASE_PATH%/assets/img/bbcode_02.png" alt="CKEditor content created in BBCode">

--- a/docs/guide/dev/howtos/pasting/README.md
+++ b/docs/guide/dev/howtos/pasting/README.md
@@ -25,7 +25,7 @@ Note, however, that by default some font styles are not preserved to avoid confl
 config.pasteFromWordRemoveFontStyles = false;
 ```
 
-Please note that since CKEditor 4.1 you need to add {@link guide/dev/acf/README Advanced Content Filter} into the equation, too. The content filtering mechanism makes sure that the data that enters the editor is supported by the editor features that are enabled in your configuration (to simplify it: if there is no font or text and background color button in your toolbar, this formatting will be stripped from your Word-formatted text). ACF is a highly flexible tool, though, so you can {@linksdk acf easily adjust it to your needs}.
+Please note that since CKEditor 4.1 you need to add {@link guide/dev/acf/README Advanced Content Filter} into the equation, too. The content filtering mechanism makes sure that the data that enters the editor is supported by the editor features that are enabled in your configuration (to simplify it: if there is no font or text and background color button in your toolbar, this formatting will be stripped from your Word-formatted text). ACF is a highly flexible tool, though, so you can {@linkexample acf easily adjust it to your needs}.
 
 ## Is Pasting from Google Docs Supported?
 

--- a/docs/guide/dev/howtos/styles/README.md
+++ b/docs/guide/dev/howtos/styles/README.md
@@ -37,7 +37,7 @@ Depending on whether your definitions were placed inline or in an external file,
 	// For a definition in an external file.
 	config.stylesSet = 'my_styles:http://www.example.com/styles.js';
 
-For more details on the definition format and best practices on how to customize the styles please refer to the {@link features/styles/README Applying Styles to Editor Content} article and see the relevant {@linksdk styles CKEditor example}.
+For more details on the definition format and best practices on how to customize the styles please refer to the {@link features/styles/README Applying Styles to Editor Content} article and see the relevant {@linkexample styles CKEditor example}.
 
 
 ### Stylesheet Parser Plugin
@@ -49,7 +49,7 @@ You can also populate the **Styles** drop-down list with style definitions added
 
 The optional [Stylesheet Parser](https://ckeditor.com/cke4/addon/stylesheetparser) plugin can be used to point to an external CSS stylesheet containing style definitions. It will help you use existing CSS styles and display them in the **Styles** drop-down list without a need to define them specifically for CKEditor as {@link guide/dev/howtos/styles/README#how-do-i-customize-the-styles-drop-down-list described here}.
 
-For more information on using the plugin refer to {@link features/styles/README#the-stylesheet-parser-plugin The Stylesheet Parser Plugin} article and see the relevant {@linksdk styles CKEditor Examples sample}.
+For more information on using the plugin refer to {@link features/styles/README#the-stylesheet-parser-plugin The Stylesheet Parser Plugin} article and see the relevant {@linkexample styles CKEditor Examples sample}.
 
 
 ## How Do I Add Custom Styles Based on CSS Classes?

--- a/docs/guide/dev/howtos/support/README.md
+++ b/docs/guide/dev/howtos/support/README.md
@@ -24,7 +24,7 @@ If you are having trouble installing, configuring, or integrating CKEditor to yo
 
 ### Documentation
 
-First of all, CKEditor comes with really extensive {@link guide/index documentation} that you should read and {@linksdk index plenty of samples} that you can try out and even download to copy and implement in your own environment.
+First of all, CKEditor comes with really extensive {@link guide/index documentation} that you should read and {@linkexample index plenty of samples} that you can try out and even download to copy and implement in your own environment.
 
 ### Stack Overflow
 

--- a/docs/guide/dev/inline/README.md
+++ b/docs/guide/dev/inline/README.md
@@ -16,7 +16,7 @@ Inline Editing is a new technology introduced in CKEditor 4 that allows you to *
 
 It is a total WYSIWYG experience, because not only the edited content looks like the final outcome, but also the page and the context where the content is placed is the real one. Unlike in {@link guide/dev/framed/README classic editor}, there is no `<iframe>` element created for the editing area. The CSS styles used for editor content are exactly the same as on the target page where this content is rendered!
 
-To try it out, see the {@linksdk inline inline editing demo}.
+To try it out, see the {@linkexample inline inline editing demo}.
 
 <img src="%BASE_PATH%/assets/img/inline_example.png" alt="Inline editor example">
 
@@ -65,7 +65,7 @@ Since CKEditor 4.2 you can also turn `<textarea>` elements into inline editors. 
 
 ## Inline Editing Demo
 
-See the {@linksdk inline working "Inline Editor" sample} that showcases a few usage scenarios for inline editing.
+See the {@linkexample inline working "Inline Editor" sample} that showcases a few usage scenarios for inline editing.
 
 ## Further Reading
 

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -135,7 +135,7 @@ Go ahead and play a bit more with the sample; try to change your configuration a
 1. Get familiar with {@link guide/dev/acf/README Advanced Content Filter}. This is a useful tool that adjusts the content inserted into CKEditor 4 to the features that are enabled and filters out disallowed content.
 1. {@link features/toolbar/README Modify your toolbar} to only include the features that you need. You can find the useful visual toolbar configurator directly in your editor sample.
 1. Learn about CKEditor 4 features in the {@link features/index Features Overview} section.
-1. Visit the {@linksdk index CKEditor Examples} to see the **huge collection of working editor samples** showcasing its features, with source code readily available to see and download.
+1. Visit the {@linkexample index CKEditor Examples} to see the **huge collection of working editor samples** showcasing its features, with source code readily available to see and download.
 1. Browse the [Add-ons Repository](https://ckeditor.com/cke4/addons/plugins/all) for some additional plugins or skins.
 1. Use [online builder](https://ckeditor.com/cke4/builder) to create your custom CKEditor 4 build.
 1. Browse the {@link guide/index Developer's Guide} for some further ideas on what to do with CKEditor 4 and join the CKEditor community at [Stack Overflow](http://stackoverflow.com/questions/tagged/ckeditor) to discuss all CKEditor things with fellow developers!

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -244,4 +244,4 @@ CKEditor types can be installed from [@types/ckeditor](https://www.npmjs.com/pac
 
 ## CKEditor 4 Angular Integration Demo
 
-See the {@linksdk angular working "CKEditor 4 Angular Integration" sample} that showcases the most iomportant features of the integration, including choosing the editor type, configuration and events, or setting up two-way data binding.
+See the {@linkexample angular working "CKEditor 4 Angular Integration" sample} that showcases the most iomportant features of the integration, including choosing the editor type, configuration and events, or setting up two-way data binding.

--- a/docs/guide/dev/integration/file_browse_upload/file_browser_api/README.md
+++ b/docs/guide/dev/integration/file_browse_upload/file_browser_api/README.md
@@ -13,7 +13,7 @@ For licensing, see LICENSE.md.
 # File Browser API - Creating a Custom File Manager
 
 <info-box info="">
-	CKEditor can be easily integrated with an external file manager (file browser/uploader) thanks to the <a href="https://ckeditor.com/cke4/addon/filebrowser">File Browser</a> plugin which by default is included in the {@linksdk standardpreset Standard} and {@linksdk fullpreset Full} presets.
+	CKEditor can be easily integrated with an external file manager (file browser/uploader) thanks to the <a href="https://ckeditor.com/cke4/addon/filebrowser">File Browser</a> plugin which by default is included in the {@linkexample standardpreset Standard} and {@linkexample fullpreset Full} presets.
 </info-box>
 
 <info-box info="">

--- a/docs/guide/dev/integration/file_browse_upload/file_upload/README.md
+++ b/docs/guide/dev/integration/file_browse_upload/file_upload/README.md
@@ -223,7 +223,7 @@ If for any reason you need to do this, note that the path to the connector must 
 
 ## Dropping and Pasting Upload Demo
 
-See the {@linksdk fileupload#uploading-dropped-and-pasted-images working "Uploading Dropped and Pasted Images" sample} for an example of the Upload Image plugin integration with CKEditor and CKFinder.
+See the {@linkexample fileupload#uploading-dropped-and-pasted-images working "Uploading Dropped and Pasted Images" sample} for an example of the Upload Image plugin integration with CKEditor and CKFinder.
 
 ## Further Reading
 

--- a/docs/guide/dev/integration/react/README.md
+++ b/docs/guide/dev/integration/react/README.md
@@ -217,4 +217,4 @@ Please note that this property is initialised asynchronously, after mounting the
 
 ## CKEditor 4 React Integration Demo
 
-See the {@linksdk react working "CKEditor 4 React Integration" sample} that showcases the most important features of the integration, including choosing the editor type, configuration and events, or setting up two-way data binding.
+See the {@linkexample react working "CKEditor 4 React Integration" sample} that showcases the most important features of the integration, including choosing the editor type, configuration and events, or setting up two-way data binding.

--- a/docs/guide/dev/integration/spreadsheets/README.md
+++ b/docs/guide/dev/integration/spreadsheets/README.md
@@ -245,7 +245,7 @@ CKEDITOR.addTemplates( 'spreadsheets', {
 } );
 ```
 
-The above template will allow inserting a 2x2 spreadsheet widget with the default ascending sorting order (in the first column) and the numeric data type (in the second column) with just two clicks. See it in action in the {@linksdk spreadsheets working "Creating Data Grids with Spreadsheet Plugin" sample}.
+The above template will allow inserting a 2x2 spreadsheet widget with the default ascending sorting order (in the first column) and the numeric data type (in the second column) with just two clicks. See it in action in the {@linkexample spreadsheets working "Creating Data Grids with Spreadsheet Plugin" sample}.
 
 ## Manipulating the Spreadsheet Widget Data via API
 
@@ -314,4 +314,4 @@ Refer to the {@link features/spreadsheets/README Creating Data Grids with Spread
 
 ## Demo
 
-See the {@linksdk spreadsheets working "Creating Data Grids with Spreadsheet Plugin" sample} that showcases the most important features like styling, sorting, conditional formatting, formulas and more.
+See the {@linkexample spreadsheets working "Creating Data Grids with Spreadsheet Plugin" sample} that showcases the most important features like styling, sorting, conditional formatting, formulas and more.

--- a/docs/guide/dev/integration/vue/README.md
+++ b/docs/guide/dev/integration/vue/README.md
@@ -341,4 +341,4 @@ Please note that this property is initialised asynchronously, after mounting the
 
 ## CKEditor 4 Vue Integration Demo
 
-See the {@linksdk vue working "CKEditor 4 Vue Integration" sample} that showcases the most important features of the integration, including choosing the editor type, configuration and events, or setting up two-way data binding.
+See the {@linkexample vue working "CKEditor 4 Vue Integration" sample} that showcases the most important features of the integration, including choosing the editor type, configuration and events, or setting up two-way data binding.

--- a/docs/guide/dev/issues_readme/README.md
+++ b/docs/guide/dev/issues_readme/README.md
@@ -16,7 +16,7 @@ If you feel you found an issue in CKEditor, we will be grateful for letting us k
 
 ## Reproduce on Demo Page
 
-To eliminate the chance that the issue might be caused by some third-party software or your customizations, try to reproduce the issue on {@linksdk standardpreset CKEditor Examples} first.
+To eliminate the chance that the issue might be caused by some third-party software or your customizations, try to reproduce the issue on {@linkexample standardpreset CKEditor Examples} first.
 
 CKEditor Examples samples are always running the latest editor version. Please note that if the problem was fixed in one of the releases that succeeded the version you are using, you will need to upgrade your CKEditor installation as we do not backport fixes.
 

--- a/docs/guide/dev/savedata/README.md
+++ b/docs/guide/dev/savedata/README.md
@@ -78,5 +78,5 @@ A dedicated **[Save](https://ckeditor.com/cke4/addon/save)** plugin for CKEditor
 
 The following samples are available for getting and saving data in CKEditor:
 
-* The {@linksdk savetextarea Saving Data in CKEditor Replacing a Textarea} sample shows how to save data for classic and inline editor replacing a `<textarea>` element.
-* The {@linksdk saveajax CKEditor in Ajax Applications} sample shows how to dynamically create and destroy the editor and how to use the {@linkapi CKEDITOR.editor#change change} event.
+* The {@linkexample savetextarea Saving Data in CKEditor Replacing a Textarea} sample shows how to save data for classic and inline editor replacing a `<textarea>` element.
+* The {@linkexample saveajax CKEditor in Ajax Applications} sample shows how to dynamically create and destroy the editor and how to use the {@linkapi CKEDITOR.editor#change change} event.

--- a/docs/guide/plugin_sdk/integration_with_acf/README.md
+++ b/docs/guide/plugin_sdk/integration_with_acf/README.md
@@ -257,7 +257,7 @@ Read more about {@linkapi CKEDITOR.feature#contentForms contentForms} in CKEdito
 
 ## Abbreviation Plugin Demo
 
-See the {@linksdk abbr working "Abbreviation (Custom Plugin with Dialog, Context Menu and ACF Support)" sample} that shows the final version of the Abbreviation plugin integrated with an editor instance.
+See the {@linkexample abbr working "Abbreviation (Custom Plugin with Dialog, Context Menu and ACF Support)" sample} that shows the final version of the Abbreviation plugin integrated with an editor instance.
 
 ## Further Reading
 

--- a/docs/guide/plugin_sdk/intro/README.md
+++ b/docs/guide/plugin_sdk/intro/README.md
@@ -30,4 +30,4 @@ Learning by example is always the best idea, so check our **plugin tutorials** t
  1. **{@link guide/plugin_sdk/integration_with_acf/README Integrating Plugins with Advanced Content Filter}** &ndash; Learn how to implement Advanced Content Filter support in your plugins.
  1. **{@link guide/plugin_sdk/styles/README Plugin Stylesheets}** &ndash; Tips on how to integrate custom plugin stylesheets with CKEditor.
  1. **{@linkapi CKEDITOR.pluginDefinition Plugin Definition API}** &ndash; Detailed description of the plugin definition.
- 1. **Live Demos** &ndash; See the **working demos** of the custom {@linksdk timestamp Timestamp} and {@linksdk abbr Abbreviation} plugins created in the tutorials live in action in CKEditor Examples.
+ 1. **Live Demos** &ndash; See the **working demos** of the custom {@linkexample timestamp Timestamp} and {@linkexample abbr Abbreviation} plugins created in the tutorials live in action in CKEditor Examples.

--- a/docs/guide/plugin_sdk/sample/README.md
+++ b/docs/guide/plugin_sdk/sample/README.md
@@ -177,7 +177,7 @@ order to insert other types of content into your document.
 
 ## Timestamp Plugin Demo
 
-See the {@linksdk timestamp working "Timestamp (Creating a Most Basic CKEditor Plugin)" sample} that shows the Timestamp plugin integrated with an editor instance.
+See the {@linkexample timestamp working "Timestamp (Creating a Most Basic CKEditor Plugin)" sample} that shows the Timestamp plugin integrated with an editor instance.
 
 ## Further Reading
 

--- a/docs/guide/widget_sdk/intro/README.md
+++ b/docs/guide/widget_sdk/intro/README.md
@@ -35,4 +35,4 @@ Learning by example is always the best idea, so check our **widget tutorials** t
 
  1. **{@link guide/widget_sdk/tutorial_1/README Part 1}** &ndash; Develop a **basic template widget** that lets the user insert a simple box with a title and comment fields into the document.
  2. **{@link guide/widget_sdk/tutorial_2/README Part 2}** &ndash; Modify the simple box widget by adding a **widget dialog window with widget editing capabilities**.
- 3. **{@linksdk simplebox Demo}** &ndash; See the **working demo** of the custom widget created in the tutorials live in action in CKEditor Examples.
+ 3. **{@linkexample simplebox Demo}** &ndash; See the **working demo** of the custom widget created in the tutorials live in action in CKEditor Examples.

--- a/docs/guide/widget_sdk/tutorial_2/README.md
+++ b/docs/guide/widget_sdk/tutorial_2/README.md
@@ -459,4 +459,4 @@ If you double click an existing widget instance, the dialog window will open aga
 
 ## Simple Box Widget Demo
 
-See the {@linksdk simplebox working "SimpleBox (Creating a Custom Widget)" sample} that shows the final version of the Simple Box widget integrated with an editor instance.
+See the {@linkexample simplebox working "SimpleBox (Creating a Custom Widget)" sample} that shows the final version of the Simple Box widget integrated with an editor instance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 
 {@link features/accessibility_checker/README Accessibility Checker documentation}
 
-{@linkexample accessibilitychecker Accessibility Checker SDK sample}
+{@linkexample accessibilitychecker Accessibility Checker sample}
 
 ## Contribute
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 
 {@link features/accessibility_checker/README Accessibility Checker documentation}
 
-{@linksdk accessibilitychecker Accessibility Checker SDK sample}
+{@linkexample accessibilitychecker Accessibility Checker SDK sample}
 
 ## Contribute
 

--- a/umberto.json
+++ b/umberto.json
@@ -198,100 +198,100 @@
 		]
 	},
 	{
-			"name": "Features",
-			"id": "features",
-			"slug": "features",
-			"categories": [
-				{
-					"name": "End-user Features",
-					"id": "end-user-features",
-					"slug": "end-user-features",
-					"order": 30,
-					"categories": [
-						{
-							"name": "User Interface",
-							"id": "user-interface",
-							"slug": "user-interface",
-							"order": 20
-						},
-						{
-							"name": "Editor Resizing",
-							"id": "editor-resizing",
-							"slug": "editor-resizing",
-							"order": 40
-						},
-						{
-							"name": "Inserting Images",
-							"id": "inserting-images",
-							"slug": "inserting-images",
-							"order": 60
-						},
-						{
-							"name": "Inserting Content",
-							"id": "inserting-content",
-							"slug": "inserting-content",
-							"order": 80
-						},
-						{
-							"name": "Styling and Formatting",
-							"id": "styling-formatting",
-							"slug": "styling-formatting",
-							"order": 100
-						},
-						{
-							"name": "Working with Document",
-							"id": "working-with-document",
-							"slug": "working-with-document",
-							"order": 120
-						},
-						{
-							"name": "Accessibility Support",
-							"id": "accessibility-support",
-							"slug": "accessibility-support",
-							"order": 140
-						}
-					]
-				},
-				{
-					"name": "Integration Features",
-					"id": "integration-features",
-					"slug": "integration-features",
-					"order": 40,
-					"categories": [
-						{
-							"name": "Editor UI",
-							"id": "editor-ui",
-							"slug": "editor-ui",
-							"order": 20
-						},
-						{
-							"name": "Toolbar",
-							"id": "toolbar",
-							"slug": "toolbar",
-							"order": 40
-						},
-						{
-							"name": "API Usage",
-							"id": "api-usage",
-							"slug": "api-usage",
-							"order": 60
-						},
-						{
-							"name": "Output Control",
-							"id": "output-control",
-							"slug": "output-control",
-							"order": 80
-						},
-						{
-							"name": "Utilities",
-							"id": "utilities",
-							"slug": "utilities",
-							"order": 100
-						}
-					]
-				}
-			]
-		},
+		"name": "Features",
+		"id": "features",
+		"slug": "features",
+		"categories": [
+			{
+				"name": "End-user Features",
+				"id": "end-user-features",
+				"slug": "end-user-features",
+				"order": 30,
+				"categories": [
+					{
+						"name": "User Interface",
+						"id": "user-interface",
+						"slug": "user-interface",
+						"order": 20
+					},
+					{
+						"name": "Editor Resizing",
+						"id": "editor-resizing",
+						"slug": "editor-resizing",
+						"order": 40
+					},
+					{
+						"name": "Inserting Images",
+						"id": "inserting-images",
+						"slug": "inserting-images",
+						"order": 60
+					},
+					{
+						"name": "Inserting Content",
+						"id": "inserting-content",
+						"slug": "inserting-content",
+						"order": 80
+					},
+					{
+						"name": "Styling and Formatting",
+						"id": "styling-formatting",
+						"slug": "styling-formatting",
+						"order": 100
+					},
+					{
+						"name": "Working with Document",
+						"id": "working-with-document",
+						"slug": "working-with-document",
+						"order": 120
+					},
+					{
+						"name": "Accessibility Support",
+						"id": "accessibility-support",
+						"slug": "accessibility-support",
+						"order": 140
+					}
+				]
+			},
+			{
+				"name": "Integration Features",
+				"id": "integration-features",
+				"slug": "integration-features",
+				"order": 40,
+				"categories": [
+					{
+						"name": "Editor UI",
+						"id": "editor-ui",
+						"slug": "editor-ui",
+						"order": 20
+					},
+					{
+						"name": "Toolbar",
+						"id": "toolbar",
+						"slug": "toolbar",
+						"order": 40
+					},
+					{
+						"name": "API Usage",
+						"id": "api-usage",
+						"slug": "api-usage",
+						"order": 60
+					},
+					{
+						"name": "Output Control",
+						"id": "output-control",
+						"slug": "output-control",
+						"order": 80
+					},
+					{
+						"name": "Utilities",
+						"id": "utilities",
+						"slug": "utilities",
+						"order": 100
+					}
+				]
+			}
+		]
+	},
 	{
 		"name": "Examples",
 		"id": "sdk",


### PR DESCRIPTION
My assumption is that:

> Replace `linksdk` with `linkexample` in umberto's links.

means replacing all `{@linksdk ...}` entries with `{@linkexample ...}` entries.

> After merge of sdk-port, there should be replaced names with SDK to names with Examples.

Probably means [ids in `umberto.json`](https://github.com/ckeditor/ckeditor4-docs/blob/0add9b56dfb5b91f0bf8bd2633a647bd54fdeab0/umberto.json#L304) and maybe [some meta tags](https://github.com/ckeditor/ckeditor4-docs/blob/0add9b56dfb5b91f0bf8bd2633a647bd54fdeab0/docs/sdk/examples/abbr.html#L11-L13) too?

---

I covered the first on `linksdk` -> `linkexample`, however it didn't changed anything because links are generated exactly the same.

As for the second one, I'm for not touching it, since we lived with more than 1,5 year, it works fine and I don't see any value in such changes. Also this is only internal stuff (not visible in docs) so it's not confusing to users in any way.

Closes ckeditor/ckeditor4#2892.