### PR TITLE
Add reference to CKEditor 5 in 'What CKEditor 4 Is Not' section

### DIFF
--- a/docs/guide/dev/basics/README.md
+++ b/docs/guide/dev/basics/README.md
@@ -42,11 +42,11 @@ There are a few scenarios where CKEditor 4 seems to be just the tool that you ne
 
 * CKEditor 4 is not a **content management system (CMS)**. It does not contain any sort of database to store your posts, logging system for user management, or administration panel where you can tweak the options for your website.
 
-* CKEditor 4 is not **desktop publishing software** (it is not MS Word!) and is not a recommended tool to use when creating paged content with fixed layout and styling that is intended for printing.
+* CKEditor 4 is not **desktop publishing software** and is not a recommended tool to use when creating paged content with fixed layout and styling that is intended for printing.
 
-* CKEditor 4 working out of the box in its default implementation is **not a tool like Google Docs**, where multiple users can edit the same article online in real time, track changes, and add comments. However, **if you need those features we have a good news for you - all of those are available in [CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)!**
+* CKEditor 4 working out of the box in its default implementation is **not a tool like Google Docs**, where multiple users can edit the same article online in real time, track changes, and add comments. However, **if you need these features, we have a good news for you &mdash; they are available in [CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)!**
 
-* CKEditor 4 is not a tool that will let you input invalid HTML code. CKEditor abides by W3C standards so it will modify code if it is invalid.
+* CKEditor 4 is not a tool that will let you **input invalid HTML code**. CKEditor 4 abides by W3C standards so it will modify HTML code if it is invalid.
 
 At the end of the day, **CKEditor 4 is an editor &mdash; nothing more, nothing less**. Go to the {@linkexample index CKEditor 4 Examples} section to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
 
@@ -56,4 +56,4 @@ Web content is created in HTML, a markup language that includes both text and sp
 
 This has some consequences, though. **CKEditor 4 works on HTML code and to do it well, it needs to get proper HTML code as input.** If the source document is incorrect, CKEditor 4 will attempt to fix it in order to be able to apply its content transformations.
 
-CKEditor 4 is not a human-being, though, so it is unable to guess your intentions when you created incorrect HTML code which may lead to some unexpected consequences. In order to avoid problems the input provider (you!) needs to make sure that what CKEditor 4 gets is clean, standards-compliant HTML code. If this is the case, CKEditor 4 will work as intended and output clean, standards-compliant HTML code in return.
+CKEditor 4 is not a human-being, though, so it is unable to guess your intentions when you created incorrect HTML code which may lead to some unexpected consequences. In order to avoid problems, the input provider (you!) needs to make sure that what CKEditor 4 gets is clean, standards-compliant HTML code. If this is the case, CKEditor 4 will work as intended and output clean, standards-compliant HTML code in return.

--- a/docs/guide/dev/basics/README.md
+++ b/docs/guide/dev/basics/README.md
@@ -44,7 +44,7 @@ There are a few scenarios where CKEditor 4 seems to be just the tool that you ne
 
 * CKEditor 4 is not **desktop publishing software** (it is not MS Word!) and is not a recommended tool to use when creating paged content with fixed layout and styling that is intended for printing.
 
-* CKEditor 4 working out of the box in its default implementation is **not a tool like Google Docs**, where multiple users can edit the same article online in real time, track changes, and add comments. However, if you need those features we have a good news for you - all of those are available in [CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)!.
+* CKEditor 4 working out of the box in its default implementation is **not a tool like Google Docs**, where multiple users can edit the same article online in real time, track changes, and add comments. However, **if you need those features we have a good news for you - all of those are available in [CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)!**.
 
 * CKEditor 4 is not a tool that will let you input invalid HTML code. CKEditor abides by W3C standards so it will modify code if it is invalid.
 

--- a/docs/guide/dev/basics/README.md
+++ b/docs/guide/dev/basics/README.md
@@ -44,7 +44,7 @@ There are a few scenarios where CKEditor 4 seems to be just the tool that you ne
 
 * CKEditor 4 is not **desktop publishing software** (it is not MS Word!) and is not a recommended tool to use when creating paged content with fixed layout and styling that is intended for printing.
 
-* CKEditor 4 working out of the box in its default implementation is **not a tool like Google Docs**, where multiple users can edit the same article online in real time, track changes, and add comments. However, **if you need those features we have a good news for you - all of those are available in [CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)!**.
+* CKEditor 4 working out of the box in its default implementation is **not a tool like Google Docs**, where multiple users can edit the same article online in real time, track changes, and add comments. However, **if you need those features we have a good news for you - all of those are available in [CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)!**
 
 * CKEditor 4 is not a tool that will let you input invalid HTML code. CKEditor abides by W3C standards so it will modify code if it is invalid.
 

--- a/docs/guide/dev/basics/README.md
+++ b/docs/guide/dev/basics/README.md
@@ -2,58 +2,58 @@
 category: getting-started
 order: 40
 url: guide/dev_basics
-menu-title: Basic CKEditor Concepts
-meta-title-short: Basic CKEditor Concepts
+menu-title: Basic CKEditor 4 Concepts
+meta-title-short: Basic CKEditor 4 Concepts
 ---
 <!--
 Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md.
 -->
 
-# Basic CKEditor Concepts
+# Basic CKEditor 4 Concepts
 
 This article aims to answer two simple questions:
 
-* What CKEditor is (and what I can use it for)?
+* What CKEditor 4 is (and what I can use it for)?
 
-* What CKEditor is not (and why it will be of no use to me)?
+* What CKEditor 4 is not (and why it will be of no use to me)?
 
-Additionally, it also explains briefly how CKEditor works and why it needs to get clean, standards-compliant code as input.
+Additionally, it also explains briefly how CKEditor 4 works and why it needs to get clean, standards-compliant code as input.
 
-## What CKEditor Is
+## What CKEditor 4 Is
 
-**CKEditor is an online WYSIWYG editor that is used to edit HTML documents (or their fragments) in the browser.**
+**CKEditor 4 is an online WYSIWYG editor that is used to edit HTML documents (or their fragments) in the browser.**
 
 So what does this mean?
 
-* The *"online"* part means that CKEditor **works in a web browser** (like Firefox, Chrome, Internet Explorer or Safari). It is thus not a standalone program that can be installed on your computer and then opened as a desktop application.
+* The *"online"* part means that CKEditor 4 **works in a web browser** (like Firefox, Chrome, Internet Explorer or Safari). It is thus not a standalone program that can be installed on your computer and then opened as a desktop application.
 
-* The *"WYSIWYG"* part means that when you use CKEditor, you can **style the text and add rich media contents to your document in real time by using the editor UI** (toolbar buttons, dialog windows), and the result will be seen immediately. If you click the **Bold** button, the text will become bold; when you add an image, it will appear straightaway.
+* The *"WYSIWYG"* part means that when you use CKEditor 4, you can **style the text and add rich media contents to your document in real time by using the editor UI** (toolbar buttons, dialog windows), and the result will be seen immediately. If you click the **Bold** button, the text will become bold; when you add an image, it will appear straightaway.
 
-* **CKEditor works on HTML**, which is a markup language used to create web content. The huge benefit that CKEditor gives you, however, is that you do not need to see the HTML code directly nor understand its intricacies. The editor is sort of an intermediary here &mdash; it hides the HTML code from you and lets you just work the WYSIWYG way.
+* **CKEditor 4 works on HTML**, which is a markup language used to create web content. The huge benefit that CKEditor 4 gives you, however, is that you do not need to see the HTML code directly nor understand its intricacies. The editor is sort of an intermediary here &mdash; it hides the HTML code from you and lets you just work the WYSIWYG way.
 
-* The *"edit HTML documents"* part means that the **editor can be used to edit any HTML content**, like website content (blog articles, blog comments, forum posts), e-mails, or things that you write in web forms. That is not all, however: CKEditor can also be used in all sorts of online applications, i.e. all those that use HTML as their source text format and are run in the browser!
+* The *"edit HTML documents"* part means that the **editor can be used to edit any HTML content**, like website content (blog articles, blog comments, forum posts), e-mails, or things that you write in web forms. That is not all, however: CKEditor 4 can also be used in all sorts of online applications, i.e. all those that use HTML as their source text format and are run in the browser!
 
-## What CKEditor Is Not
+## What CKEditor 4 Is Not
 
-There are a few scenarios where CKEditor seems to be just the tool that you need while in fact this is not the case. For example:
+There are a few scenarios where CKEditor 4 seems to be just the tool that you need while in fact this is not the case. For example:
 
-* CKEditor is neither a **graphical web design tool** nor a website builder. If you want a tool that will help you design your website, CKEditor is not what you are looking for.
+* CKEditor 4 is neither a **graphical web design tool** nor a website builder. If you want a tool that will help you design your website, CKEditor 4 is not what you are looking for.
 
-* CKEditor is not a **content management system (CMS)**. It does not contain any sort of database to store your posts, logging system for user management, or administration panel where you can tweak the options for your website.
+* CKEditor 4 is not a **content management system (CMS)**. It does not contain any sort of database to store your posts, logging system for user management, or administration panel where you can tweak the options for your website.
 
-* CKEditor is not **desktop publishing software** (it is not Word!) and is not a recommended tool to use when creating paged content with fixed layout and styling that is intended for printing.
+* CKEditor 4 is not **desktop publishing software** (it is not MS Word!) and is not a recommended tool to use when creating paged content with fixed layout and styling that is intended for printing.
 
-* CKEditor working out of the box in its default implementation is **not a tool like Google Docs**, where multiple users can edit the same article online in real time, track changes, and add comments. You can however try to find some plugins or tools that will help you expand its possibilities.
+* CKEditor 4 working out of the box in its default implementation is **not a tool like Google Docs**, where multiple users can edit the same article online in real time, track changes, and add comments. However, if you need those features we have a good news for you - all of those are available in [CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)!.
 
-* CKEditor is not a tool that will let you input invalid HTML code. CKEditor abides by W3C standards so it will modify code if it is invalid.
+* CKEditor 4 is not a tool that will let you input invalid HTML code. CKEditor abides by W3C standards so it will modify code if it is invalid.
 
-At the end of the day, **CKEditor is an editor &mdash; nothing more, nothing less**. Go to the {@linkexample index CKEditor Examples} section to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
+At the end of the day, **CKEditor 4 is an editor &mdash; nothing more, nothing less**. Go to the {@linkexample index CKEditor 4 Examples} section to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
 
-## How CKEditor Works
+## How CKEditor 4 Works
 
-Web content is created in HTML, a markup language that includes both text and special tags that describe this text as well as add semantic meaning to it. These tags are used to mark particular content elements as "headings", "paragraphs", "bold text", etc. CKEditor merely hides the HTML tags from the user and shows their equivalents in the graphical user interface (like the Bold toolbar button) as well as outputs the text with formatting already applied.
+Web content is created in HTML, a markup language that includes both text and special tags that describe this text as well as add semantic meaning to it. These tags are used to mark particular content elements as "headings", "paragraphs", "bold text", etc. CKEditor 4 merely hides the HTML tags from the user and shows their equivalents in the graphical user interface (like the Bold toolbar button) as well as outputs the text with formatting already applied.
 
-This has some consequences, though. **CKEditor works on HTML code and to do it well, it needs to get proper HTML code as input.** If the source document is incorrect, CKEditor will attempt to fix it in order to be able to apply its content transformations.
+This has some consequences, though. **CKEditor 4 works on HTML code and to do it well, it needs to get proper HTML code as input.** If the source document is incorrect, CKEditor 4 will attempt to fix it in order to be able to apply its content transformations.
 
-CKEditor is not a human-being, though, so it is unable to guess your intentions when you created incorrect HTML code which may lead to some unexpected consequences. In order to avoid problems the input provider (you!) needs to make sure that what CKEditor gets is clean, standards-compliant HTML code. If this is the case, CKEditor will work as intended and output clean, standards-compliant HTML code in return.
+CKEditor 4 is not a human-being, though, so it is unable to guess your intentions when you created incorrect HTML code which may lead to some unexpected consequences. In order to avoid problems the input provider (you!) needs to make sure that what CKEditor 4 gets is clean, standards-compliant HTML code. If this is the case, CKEditor 4 will work as intended and output clean, standards-compliant HTML code in return.

--- a/docs/guide/dev/best_practices/README.md
+++ b/docs/guide/dev/best_practices/README.md
@@ -65,7 +65,7 @@ The default styles included in the `styles.js` file are just examples which will
 ## Integration
 
 ### Input clean HTML code
-You should only ever input clean, standards-compliant HTML code into CKEditor. {@link guide/dev/basics/README#how-ckeditor-works Incorrect markup will be modified by CKEditor} which may lead to unexpected results.
+You should only ever input clean, standards-compliant HTML code into CKEditor. {@link guide/dev/basics/README#how-ckeditor-4-works Incorrect markup will be modified by CKEditor} which may lead to unexpected results.
 
 ### Use UTF-8
 To avoid problems with character encoding, use UTF-8 for your websites and your database. Just set the `<meta>` element for your pages to:
@@ -81,7 +81,7 @@ or, if you are using the HTML5 `DOCTYPE`, to:
 ```
 
 ### Use CKEditor for what it was made for
-Last but not least, {@link guide/dev/basics/README#what-ckeditor-is use CKEditor for what it was designed for}. Learn from the best: Visit the {@linkexample index CKEditor Examples} to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
+Last but not least, {@link guide/dev/basics/README#what-ckeditor-4-is use CKEditor for what it was designed for}. Learn from the best: Visit the {@linkexample index CKEditor Examples} to see plenty of valid editor use cases, with source code ready to copy and implement in your own solution!
 
 ## Security
 

--- a/docs/guide/dev/framed/README.md
+++ b/docs/guide/dev/framed/README.md
@@ -14,7 +14,7 @@ For licensing, see LICENSE.md.
 
 Classic editing is still probably the most common way to use CKEditor. In this usage scenario the editor is most often represented by a toolbar and an editing area placed in a specific position on the page, usually as a part of a form that you use to submit some content to the server. Sometimes it is also called "framed editing", because in this case the editor creates a temporary `<iframe>` element for itself.
 
-This method is used in the {@link guide/dev/installation/README#adding-ckeditor-to-your-page Quick Start Guide} example. To try it out, see also the {@linkexample classic classic editing demo}.
+This method is used in the {@link guide/dev/installation/README#adding-ckeditor-4-to-your-page Quick Start Guide} example. To try it out, see also the {@linkexample classic classic editing demo}.
 
 <img src="%BASE_PATH%/assets/img/classic_example.png" alt="Classic editor example">
 

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -10,9 +10,9 @@ Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md.
 -->
 
-# CKEditor Quick Start Guide
+# CKEditor 4 Quick Start Guide
 
-The aim of this article is to get you up and running with CKEditor in two minutes.
+The aim of this article is to get you up and running with CKEditor 4 in two minutes.
 
 ## Install from the npm Registry
 
@@ -86,14 +86,14 @@ When using the npm package open the following:
 
 Additionally, you can click the Toolbar Configurator button on the editor sample page to open a handy tool that will let you {@link features/toolbar/README adjust the toolbar} to your needs.
 
-## Adding CKEditor to Your Page
+## Adding CKEditor 4 to Your Page
 
-If the sample works correctly, you are ready to build your own site with CKEditor included.
+If the sample works correctly, you are ready to build your own site with CKEditor 4 included.
 
 To start, create a simple HTML page with a `<textarea>` element in it. You will then need to do two things:
 
 1. Include the `<script>` element loading CKEditor 4 in your page.
-2. Use the {@linkapi CKEDITOR#replace `CKEDITOR.replace()`} method to replace the existing `<textarea>` element with CKEditor.
+2. Use the {@linkapi CKEDITOR#replace `CKEDITOR.replace()`} method to replace the existing `<textarea>` element with CKEditor 4.
 
 See the following example:
 
@@ -102,17 +102,17 @@ See the following example:
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>A Simple Page with CKEditor</title>
+        <title>A Simple Page with CKEditor 4</title>
         <!-- Make sure the path to CKEditor is correct. -->
         <script src="../ckeditor.js"></script>
     </head>
     <body>
         <form>
             <textarea name="editor1" id="editor1" rows="10" cols="80">
-                This is my textarea to be replaced with CKEditor.
+                This is my textarea to be replaced with CKEditor 4.
             </textarea>
             <script>
-                // Replace the <textarea id="editor1"> with a CKEditor
+                // Replace the <textarea id="editor1"> with a CKEditor 4
                 // instance, using default configuration.
                 {@linkapi CKEDITOR.replace CKEDITOR.replace}( 'editor1' );
             </script>
@@ -125,7 +125,7 @@ When you are done, open your test page in the browser.
 
 **Congratulations! You have just installed and used CKEditor 4 on your own page in virtually no time!**
 
-{@img assets/img/ckeditor_on_page.png CKEditor added to your sample page}
+{@img assets/img/ckeditor_on_page.png CKEditor 4 added to your sample page}
 
 ## Next Steps
 
@@ -135,7 +135,7 @@ Go ahead and play a bit more with the sample; try to change your configuration a
 1. Get familiar with {@link guide/dev/acf/README Advanced Content Filter}. This is a useful tool that adjusts the content inserted into CKEditor 4 to the features that are enabled and filters out disallowed content.
 1. {@link features/toolbar/README Modify your toolbar} to only include the features that you need. You can find the useful visual toolbar configurator directly in your editor sample.
 1. Learn about CKEditor 4 features in the {@link features/index Features Overview} section.
-1. Visit the {@linkexample index CKEditor Examples} to see the **huge collection of working editor samples** showcasing its features, with source code readily available to see and download.
+1. Visit the {@linkexample index CKEditor 4 Examples} to see the **huge collection of working editor samples** showcasing its features, with source code readily available to see and download.
 1. Browse the [Add-ons Repository](https://ckeditor.com/cke4/addons/plugins/all) for some additional plugins or skins.
 1. Use [online builder](https://ckeditor.com/cke4/builder) to create your custom CKEditor 4 build.
 1. Browse the {@link guide/index Developer's Guide} for some further ideas on what to do with CKEditor 4 and join the CKEditor community at [Stack Overflow](http://stackoverflow.com/questions/tagged/ckeditor) to discuss all CKEditor things with fellow developers!

--- a/docs/guide/dev/savedata/README.md
+++ b/docs/guide/dev/savedata/README.md
@@ -41,7 +41,7 @@ When CKEditor functions as a replacement for a `<textarea>` element, the integra
 
 This means that when submitting a form containing an editor instance, its data will simply be posted to the server, using the `<textarea>` element name as the key to retrieve it.
 
-For example, for the `<textarea>` element with an ID of `editor1`, as used in our {@link guide/dev/installation/README#adding-ckeditor-to-your-page Quick Start Guide example}, you could create this PHP code:
+For example, for the `<textarea>` element with an ID of `editor1`, as used in our {@link guide/dev/installation/README#adding-ckeditor-4-to-your-page Quick Start Guide example}, you could create this PHP code:
 
 ``` php
 <?php


### PR DESCRIPTION
Besides just adding short info about CKEditor 5, I also extended `CKEditor` phrase by adding version number (`4`). I started doing this in some other visible places, but realised it's rather a separate task. Still, I didn't remove what I've already done, so some references are changed (I don't think it looks inconsistent or sth right now).

Closes ckeditor/ckeditor4#3873.