### PR TITLE
Add mention about colorName property for color button plugin.

### DIFF
--- a/docs/features/colorbutton/README.md
+++ b/docs/features/colorbutton/README.md
@@ -72,7 +72,7 @@ CKEditor will then output the color definition as `<font>` elements with `color`
 	<p><font color="#800080">This is my text color.</font><br/>
 	<font style="background-color:#FFFF00;">This is my background color</font></p>
 
-In CKEditor 4.15.0 we introduced `colorName` property which uses color name instead of color code, which allows creating descriptive class names.
+In CKEditor `4.15` `colorName` property has been introduced which uses color name instead of a color code, which allows creating descriptive class names.
 
 You can use `colorName` with {@linkapi CKEDITOR.config.colorButton_foreStyle CKEDITOR.config.colorButton_foreStyle} or {@linkapi CKEDITOR.config.colorButton_backStyle CKEDITOR.config.colorButton_backStyle} configuration options:
 
@@ -94,7 +94,7 @@ CKEditor 4 will then output the color definition as `span` with class:
 <span class="text-skyblue">Text</span>
 ```
 
-You customize color names to more friendly names by setting {@linkapi CKEDITOR.config.colorButton_colors custom color names}.
+You can customize color names to more friendly form by setting {@linkapi CKEDITOR.config.colorButton_colors custom color names}:
 
 ```javascript
 config.colorButton_colors = 'skyblue/87CEEB,crimson/DC143C';

--- a/docs/features/colorbutton/README.md
+++ b/docs/features/colorbutton/README.md
@@ -72,28 +72,32 @@ CKEditor will then output the color definition as `<font>` elements with `color`
 	<p><font color="#800080">This is my text color.</font><br/>
 	<font style="background-color:#FFFF00;">This is my background color</font></p>
 
-Since CKEditor 4.15.0 it is possible to use `class` instead of `style` to set more advanced styles to text.
+In CKEditor 4.15.0 we introduced `colorName` property which uses color name instead of color code, which allows creating descriptive class names.
 
-You need to set {@linkapi CKEDITOR.config.colorButton_colors custom color names}.
-
-You can set `colorName` to {@linkapi CKEDITOR.config.colorButton_foreStyle CKEDITOR.config.colorButton_foreStyle} or {@linkapi CKEDITOR.config.colorButton_backStyle CKEDITOR.config.colorButton_backStyle} configuration options:
+You can use `colorName` with {@linkapi CKEDITOR.config.colorButton_foreStyle CKEDITOR.config.colorButton_foreStyle} or {@linkapi CKEDITOR.config.colorButton_backStyle CKEDITOR.config.colorButton_backStyle} configuration options:
 
 ```javascript
 config.colorButton_foreStyle = {
 	element: 'span',
-	attributes: { 'class': '#(colorName)' }
+	attributes: { 'class': 'text-#(colorName)' }
 };
 
 config.colorButton_backStyle = {
 	element: 'span',
-	attributes: { 'class': '#(colorName)' }
+	attributes: { 'class': 'text-#(colorName)' }
 };
 ```
 
 CKEditor 4 will then output the color definition as `span` with class:
 
 ```html
-<span class="subtext">Text</span>
+<span class="text-skyblue">Text</span>
+```
+
+You customize color names to more friendly names by setting {@linkapi CKEDITOR.config.colorButton_colors custom color names}.
+
+```javascript
+config.colorButton_colors = 'skyblue/87CEEB,crimson/DC143C';
 ```
 
 ## Text and Background Color Demo

--- a/docs/features/colorbutton/README.md
+++ b/docs/features/colorbutton/README.md
@@ -72,6 +72,30 @@ CKEditor will then output the color definition as `<font>` elements with `color`
 	<p><font color="#800080">This is my text color.</font><br/>
 	<font style="background-color:#FFFF00;">This is my background color</font></p>
 
+Since CKEditor 4.15.0 it is possible to use `class` instead of `style` to set more advanced styles to text.
+
+You need to set {@linkapi CKEDITOR.config.colorButton_colors custom color names}.
+
+You can set `colorName` to {@linkapi CKEDITOR.config.colorButton_foreStyle CKEDITOR.config.colorButton_foreStyle} or {@linkapi CKEDITOR.config.colorButton_backStyle CKEDITOR.config.colorButton_backStyle} configuration options:
+
+```javascript
+config.colorButton_foreStyle = {
+	element: 'span',
+	attributes: { 'class': '#(colorName)' }
+};
+
+config.colorButton_backStyle = {
+	element: 'span',
+	attributes: { 'class': '#(colorName)' }
+};
+```
+
+CKEditor 4 will then output the color definition as `span` with class:
+
+```html
+<span class="subtext">Text</span>
+```
+
 ## Text and Background Color Demo
 
 See the {@linksdk colorbutton working "Setting Text and Background Color" sample} that showcases the usage and customization of the text and background color features.


### PR DESCRIPTION
Introduce `colorName` property for customizing foreground and background styles in color button plugin.

Closes https://github.com/ckeditor/ckeditor4/issues/4004.