### PR TITLE
Hotfixes for 'Export to PDF' plugin

### DIFF
--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -122,6 +122,8 @@ config.exportPdf_options = {
 	header_html: '<div class="styled">Header content</div>',
 	footer_html: '<div class="styled-counter"><span class="pageNumber"></span></div>',
 	header_and_footer_css: '.styled { font-weight: bold; padding: 10px; } .styled-counter { font-size: 1em; color: hsl(0, 0%, 60%); }',
+	margin_top: '2cm',
+	margin_bottom: '2cm'
 }
 ```
 
@@ -181,22 +183,18 @@ It is even possible to run some asynchronous tasks before sending the data to th
 
 ```js
 editor.on( 'exportPdf', function( evt ) {
-	// Let's call some asynchronous function here, like an Ajax request. Flag processing as 'in progress'.
-	evt.data.asyncDone = false;
-
-	ajaxRequestForAdditionalData( evt.editor, function() {
-		// Ajax call is done, let's mark processing as done and refire the 'exportPdf' event.
-		evt.data.asyncDone = true;
-		editor.fire( 'exportPdf', evt.data );
-	} );
-}, null, null, 1 );
-
-editor.on( 'exportPdf', function( evt ) {
-	// Stop the event if the asynchronous process is still on.
+	// Stop the event if the asynchronous process was not carried out yet.
 	if ( !evt.data.asyncDone ) {
 		evt.cancel();
+
+		// Let's call some asynchronous function here, like an Ajax request.
+		ajaxRequestForAdditionalData( evt.editor, function() {
+			// When Ajax call is done, mark processing as 'done' and refire the 'exportPdf' event.
+			evt.data.asyncDone = true;
+			editor.fire( 'exportPdf', evt.data );
+		} );
 	}
-} );
+}, null, null, 1 );
 ```
 
 ## Export to PDF Demo

--- a/docs/sdk/examples/assets/css/exportpdf.css
+++ b/docs/sdk/examples/assets/css/exportpdf.css
@@ -1,9 +1,0 @@
-body.document-editor {
-	width: 750px;
-	padding: 20px;
-	margin: 0.5cm auto;
-	border: 1px #D3D3D3 solid;
-	border-radius: 5px;
-	background: white;
-	box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-}

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -168,8 +168,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</script>
 
 		<script data-sample="1">
-			// Use these styles and wrap the editor '<textarea>' element with a '<div class=container>' one
-			// to set the "page view" display style like in the demo and matching styles for export to PDF.
+			// Use these styles to set the "page view" display style like in the demo and matching styles for export to PDF.
 			CKEDITOR.addCss(
 				'body.document-editor { margin: 0.5cm auto; border: 1px #D3D3D3 solid; border-radius: 5px; background: white; box-shadow: 0 0 5px rgba(0, 0, 0, 0.1); }' +
 				'body.document-editor, div.cke_editable { width: 700px; padding: 1cm 2cm 2cm; } ' +

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -67,83 +67,81 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</span>
 		</p>
 
-		<div class="container">
-			<textarea id="editor" data-sample="1" data-sample-short>
-				<h1 style="text-align:center"><img alt="Bilancino Hotel logo" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/bilancino-logo.png" style="float:right;height:75px;width:75px;" /><span style="font-family:Georgia,serif">The Flavorful Tuscany Meetup</span></h1>
+		<textarea id="editor" data-sample="1" data-sample-short>
+			<h1 style="text-align:center"><img alt="Bilancino Hotel logo" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/bilancino-logo.png" style="float:right;height:75px;width:75px;" /><span style="font-family:Georgia,serif">The Flavorful Tuscany Meetup</span></h1>
 
-				<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">Welcome letter</span></span></h2>
+			<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">Welcome letter</span></span></h2>
 
-				<p>Dear Guest,</p>
+			<p>Dear Guest,</p>
 
-				<p>We are delighted to welcome you to the annual <em>Flavorful Tuscany Meetup</em> and hope you will enjoy the programme as well as your stay at the <a href="https://ckeditor.com">Bilancino Hotel</a>.</p>
+			<p>We are delighted to welcome you to the annual <em>Flavorful Tuscany Meetup</em> and hope you will enjoy the programme as well as your stay at the <a href="https://ckeditor.com">Bilancino Hotel</a>.</p>
 
-				<p>Please find attached the full schedule of the event.</p>
+			<p>Please find attached the full schedule of the event.</p>
 
-				<blockquote>
-					<p>The annual Flavorful Tuscany meetups are always a culinary discovery. You get the best of Tuscan flavors during an intense one-day stay at one of the top hotels of the region. All the sessions are lead by top chefs passionate about their profession. I would certainly recommend to save the date in your calendar for this one!</p>
+			<blockquote>
+				<p>The annual Flavorful Tuscany meetups are always a culinary discovery. You get the best of Tuscan flavors during an intense one-day stay at one of the top hotels of the region. All the sessions are lead by top chefs passionate about their profession. I would certainly recommend to save the date in your calendar for this one!</p>
 
-					<p>Angelina Calvino, food journalist</p>
-				</blockquote>
+				<p>Angelina Calvino, food journalist</p>
+			</blockquote>
 
-				<p>Please arrive at the <a href="https://ckeditor.com">Bilancino Hotel</a> reception desk at least <strong>half an hour earlier</strong> to make sure that the registration process goes as smoothly as possible.</p>
+			<p>Please arrive at the <a href="https://ckeditor.com">Bilancino Hotel</a> reception desk at least <strong>half an hour earlier</strong> to make sure that the registration process goes as smoothly as possible.</p>
 
-				<p>We look forward to welcoming you to the event.</p>
+			<p>We look forward to welcoming you to the event.</p>
 
-				<p><img alt="Victoria Valc signature" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/signature.png" style="height:101px;width:180px" /></p>
+			<p><img alt="Victoria Valc signature" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/signature.png" style="height:101px;width:180px" /></p>
 
-				<p><span style="font-size:16px"><strong>Victoria Valc</strong></span></p>
+			<p><span style="font-size:16px"><strong>Victoria Valc</strong></span></p>
 
-				<p><strong>Event Manager<br />
-				Bilancino Hotel</strong></p>
+			<p><strong>Event Manager<br />
+			Bilancino Hotel</strong></p>
 
-				<p>&nbsp;</p>
+			<p>&nbsp;</p>
 
-				<div style="page-break-after: always"><span style="display:none">&nbsp;</span></div>
+			<div style="page-break-after: always"><span style="display:none">&nbsp;</span></div>
 
-				<p>&nbsp;</p>
+			<p>&nbsp;</p>
 
-				<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">The Flavorful Tuscany Meetup Schedule</span></span></h2>
+			<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">The Flavorful Tuscany Meetup Schedule</span></span></h2>
 
-				<table align="center" border="1" cellspacing="0" style="border-collapse:collapse; width:597px">
-					<thead>
-						<tr>
-							<th colspan="2" style="background-color: rgb(153, 153, 153);"><span style="color:#ffffff">Saturday, July 14</span></th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td style="background-color:#e6e6e6; text-align:center">9:30 AM - 11:30 AM</td>
-							<td>
-								<p style="text-align:left"><strong>Americano vs. Brewed - “know your coffee”</strong> with:&nbsp;</p>
+			<table align="center" border="1" cellspacing="0" style="border-collapse:collapse; width:597px">
+				<thead>
+					<tr>
+						<th colspan="2" style="background-color: rgb(153, 153, 153);"><span style="color:#ffffff">Saturday, July 14</span></th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td style="background-color:#e6e6e6; text-align:center">9:30 AM - 11:30 AM</td>
+						<td>
+							<p style="text-align:left"><strong>Americano vs. Brewed - “know your coffee”</strong> with:&nbsp;</p>
 
-								<ul>
-									<li>Giulia Bianchi</li>
-									<li>Stefano Garau</li>
-									<li>Giuseppe Russo</li>
-								</ul>
-							</td>
-						</tr>
-						<tr>
-							<td style="background-color:#e6e6e6; text-align:center">1:00 PM - 3:00 PM</td>
-							<td>
-								<p style="text-align:left"><strong>Pappardelle al pomodoro</strong> - live cooking</p>
+							<ul>
+								<li>Giulia Bianchi</li>
+								<li>Stefano Garau</li>
+								<li>Giuseppe Russo</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<td style="background-color:#e6e6e6; text-align:center">1:00 PM - 3:00 PM</td>
+						<td>
+							<p style="text-align:left"><strong>Pappardelle al pomodoro</strong> - live cooking</p>
 
-								<p style="text-align:left">Incorporate the freshest ingredients&nbsp;<br />
-								with Rita Fresco</p>
-							</td>
-						</tr>
-						<tr>
-							<td style="background-color:#e6e6e6; text-align:center">5:00 PM - 8:00 PM</td>
-							<td>
-								<p style="text-align:left"><strong>Tuscan vineyards at a glance</strong></p>
+							<p style="text-align:left">Incorporate the freshest ingredients&nbsp;<br />
+							with Rita Fresco</p>
+						</td>
+					</tr>
+					<tr>
+						<td style="background-color:#e6e6e6; text-align:center">5:00 PM - 8:00 PM</td>
+						<td>
+							<p style="text-align:left"><strong>Tuscan vineyards at a glance</strong></p>
 
-								<p style="text-align:left">Wine-tasting with Frederico Riscoli</p>
-							</td>
-						</tr>
-					</tbody>
-				</table>
-			</textarea>
-		</div>
+							<p style="text-align:left">Wine-tasting with Frederico Riscoli</p>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</textarea>
 
 		<p>
 			The crucial aspect of this feature is its configuration. In order to ensure that the generated PDF looks as close as possible to the same content when it is displayed in the WYSIWYG editor, the feature should be carefully configured. Refer to the <a href="https://ckeditor.com/docs/ckeditor4/latest/features/exporttopdf.html#configuration">documentation</a> for an overview of the configuration options available in both the plugin and the HTML to PDF converter.

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -170,7 +170,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</script>
 
 		<script data-sample="1">
-			// Use these styles and wrap the editor 'textarea' element with a '<div class=container></div>' one
+			// Use these styles and wrap the editor '<textarea>' element with a '<div class=container>' one
 			// to set the "page view" display style like in the demo and matching styles for export to PDF.
 			CKEDITOR.addCss(
 				'body.document-editor { margin: 0.5cm auto; border: 1px #D3D3D3 solid; border-radius: 5px; background: white; box-shadow: 0 0 5px rgba(0, 0, 0, 0.1); }' +

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -195,9 +195,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					{ name: 'align', items: [ 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock' ] },
 					{ name: 'document', items: [ 'PageBreak', 'Source' ] }
 				],
-				contentsCss: [
-					CKEDITOR.basePath + 'contents.css'
-				],
 				bodyClass: 'document-editor'
 			} );
 		</script>

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -168,7 +168,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</script>
 
 		<script data-sample="1">
-			// Use these styles to set the "page view" display style like in the demo and matching styles for export to PDF.
+			// These styles are used to provide the "page view" display style like in the demo and matching styles for export to PDF.
 			CKEDITOR.addCss(
 				'body.document-editor { margin: 0.5cm auto; border: 1px #D3D3D3 solid; border-radius: 5px; background: white; box-shadow: 0 0 5px rgba(0, 0, 0, 0.1); }' +
 				'body.document-editor, div.cke_editable { width: 700px; padding: 1cm 2cm 2cm; } ' +

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -67,9 +67,9 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</span>
 		</p>
 
-		<div class="container" data-sample="1" data-sample-short>
+		<div class="container">
 			<div class="inner-container">
-				<textarea id="editor">
+				<textarea id="editor" data-sample="1" data-sample-short>
 					<h1 style="text-align:center"><img alt="Bilancino Hotel logo" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/bilancino-logo.png" style="float:right;height:75px;width:75px;" /><span style="font-family:Georgia,serif">The Flavorful Tuscany Meetup</span></h1>
 
 					<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">Welcome letter</span></span></h2>

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -68,83 +68,81 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</p>
 
 		<div class="container">
-			<div class="inner-container">
-				<textarea id="editor" data-sample="1" data-sample-short>
-					<h1 style="text-align:center"><img alt="Bilancino Hotel logo" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/bilancino-logo.png" style="float:right;height:75px;width:75px;" /><span style="font-family:Georgia,serif">The Flavorful Tuscany Meetup</span></h1>
+			<textarea id="editor" data-sample="1" data-sample-short>
+				<h1 style="text-align:center"><img alt="Bilancino Hotel logo" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/bilancino-logo.png" style="float:right;height:75px;width:75px;" /><span style="font-family:Georgia,serif">The Flavorful Tuscany Meetup</span></h1>
 
-					<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">Welcome letter</span></span></h2>
+				<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">Welcome letter</span></span></h2>
 
-					<p>Dear Guest,</p>
+				<p>Dear Guest,</p>
 
-					<p>We are delighted to welcome you to the annual <em>Flavorful Tuscany Meetup</em> and hope you will enjoy the programme as well as your stay at the <a href="https://ckeditor.com">Bilancino Hotel</a>.</p>
+				<p>We are delighted to welcome you to the annual <em>Flavorful Tuscany Meetup</em> and hope you will enjoy the programme as well as your stay at the <a href="https://ckeditor.com">Bilancino Hotel</a>.</p>
 
-					<p>Please find attached the full schedule of the event.</p>
+				<p>Please find attached the full schedule of the event.</p>
 
-					<blockquote>
-						<p>The annual Flavorful Tuscany meetups are always a culinary discovery. You get the best of Tuscan flavors during an intense one-day stay at one of the top hotels of the region. All the sessions are lead by top chefs passionate about their profession. I would certainly recommend to save the date in your calendar for this one!</p>
+				<blockquote>
+					<p>The annual Flavorful Tuscany meetups are always a culinary discovery. You get the best of Tuscan flavors during an intense one-day stay at one of the top hotels of the region. All the sessions are lead by top chefs passionate about their profession. I would certainly recommend to save the date in your calendar for this one!</p>
 
-						<p>Angelina Calvino, food journalist</p>
-					</blockquote>
+					<p>Angelina Calvino, food journalist</p>
+				</blockquote>
 
-					<p>Please arrive at the <a href="https://ckeditor.com">Bilancino Hotel</a> reception desk at least <strong>half an hour earlier</strong> to make sure that the registration process goes as smoothly as possible.</p>
+				<p>Please arrive at the <a href="https://ckeditor.com">Bilancino Hotel</a> reception desk at least <strong>half an hour earlier</strong> to make sure that the registration process goes as smoothly as possible.</p>
 
-					<p>We look forward to welcoming you to the event.</p>
+				<p>We look forward to welcoming you to the event.</p>
 
-					<p><img alt="Victoria Valc signature" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/signature.png" style="height:101px;width:180px" /></p>
+				<p><img alt="Victoria Valc signature" src="https://ckeditor.com/docs/ckeditor4/latest/examples/assets/image/signature.png" style="height:101px;width:180px" /></p>
 
-					<p><span style="font-size:16px"><strong>Victoria Valc</strong></span></p>
+				<p><span style="font-size:16px"><strong>Victoria Valc</strong></span></p>
 
-					<p><strong>Event Manager<br />
-					Bilancino Hotel</strong></p>
+				<p><strong>Event Manager<br />
+				Bilancino Hotel</strong></p>
 
-					<p>&nbsp;</p>
+				<p>&nbsp;</p>
 
-					<div style="page-break-after: always"><span style="display:none">&nbsp;</span></div>
+				<div style="page-break-after: always"><span style="display:none">&nbsp;</span></div>
 
-					<p>&nbsp;</p>
+				<p>&nbsp;</p>
 
-					<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">The Flavorful Tuscany Meetup Schedule</span></span></h2>
+				<h2 style="text-align:center"><span style="font-family:Georgia,serif"><span style="color:#2980b9">The Flavorful Tuscany Meetup Schedule</span></span></h2>
 
-					<table align="center" border="1" cellspacing="0" style="border-collapse:collapse; width:597px">
-						<thead>
-							<tr>
-								<th colspan="2" style="background-color: rgb(153, 153, 153);"><span style="color:#ffffff">Saturday, July 14</span></th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td style="background-color:#e6e6e6; text-align:center">9:30 AM - 11:30 AM</td>
-								<td>
-									<p style="text-align:left"><strong>Americano vs. Brewed - “know your coffee”</strong> with:&nbsp;</p>
+				<table align="center" border="1" cellspacing="0" style="border-collapse:collapse; width:597px">
+					<thead>
+						<tr>
+							<th colspan="2" style="background-color: rgb(153, 153, 153);"><span style="color:#ffffff">Saturday, July 14</span></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td style="background-color:#e6e6e6; text-align:center">9:30 AM - 11:30 AM</td>
+							<td>
+								<p style="text-align:left"><strong>Americano vs. Brewed - “know your coffee”</strong> with:&nbsp;</p>
 
-									<ul>
-										<li>Giulia Bianchi</li>
-										<li>Stefano Garau</li>
-										<li>Giuseppe Russo</li>
-									</ul>
-								</td>
-							</tr>
-							<tr>
-								<td style="background-color:#e6e6e6; text-align:center">1:00 PM - 3:00 PM</td>
-								<td>
-									<p style="text-align:left"><strong>Pappardelle al pomodoro</strong> - live cooking</p>
+								<ul>
+									<li>Giulia Bianchi</li>
+									<li>Stefano Garau</li>
+									<li>Giuseppe Russo</li>
+								</ul>
+							</td>
+						</tr>
+						<tr>
+							<td style="background-color:#e6e6e6; text-align:center">1:00 PM - 3:00 PM</td>
+							<td>
+								<p style="text-align:left"><strong>Pappardelle al pomodoro</strong> - live cooking</p>
 
-									<p style="text-align:left">Incorporate the freshest ingredients&nbsp;<br />
-									with Rita Fresco</p>
-								</td>
-							</tr>
-							<tr>
-								<td style="background-color:#e6e6e6; text-align:center">5:00 PM - 8:00 PM</td>
-								<td>
-									<p style="text-align:left"><strong>Tuscan vineyards at a glance</strong></p>
+								<p style="text-align:left">Incorporate the freshest ingredients&nbsp;<br />
+								with Rita Fresco</p>
+							</td>
+						</tr>
+						<tr>
+							<td style="background-color:#e6e6e6; text-align:center">5:00 PM - 8:00 PM</td>
+							<td>
+								<p style="text-align:left"><strong>Tuscan vineyards at a glance</strong></p>
 
-									<p style="text-align:left">Wine-tasting with Frederico Riscoli</p>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</textarea>
-			</div>
+								<p style="text-align:left">Wine-tasting with Frederico Riscoli</p>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</textarea>
 		</div>
 
 		<p>
@@ -163,12 +161,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<script>
 			CKEDITOR.plugins.addExternal( 'exportpdf', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/exportpdf/', 'plugin.js' );
 
-			CKEDITOR.addCss(
-				'body.document-editor, div.cke_editable { width: 700px; padding: 1cm 2cm 2cm; } ' +
-				'blockquote { font-family: sans-serif, Arial, Verdana, "Trebuchet MS", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; } ' +
-				'body.document-editor table td > p, div.cke_editable table td > p { margin-top: 0; margin-bottom: 0; padding: 4px 0 3px 5px;} ' +
-				'body.document-editor { width: 750px; padding: 20px; margin: 0.5cm auto; border: 1px #D3D3D3 solid; border-radius: 5px; background: white; box-shadow: 0 0 5px rgba(0, 0, 0, 0.1); }' );
-
 			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 				var supportInfoEl = document.querySelector( '#browserSupportInfo' );
 				supportInfoEl.style.display = 'block';
@@ -178,6 +170,14 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</script>
 
 		<script data-sample="1">
+			// Use these styles and wrap the editor 'textarea' element with a '<div class=container></div>' one
+			// to set the "page view" display style like in the demo and matching styles for export to PDF.
+			CKEDITOR.addCss(
+				'body.document-editor { margin: 0.5cm auto; border: 1px #D3D3D3 solid; border-radius: 5px; background: white; box-shadow: 0 0 5px rgba(0, 0, 0, 0.1); }' +
+				'body.document-editor, div.cke_editable { width: 700px; padding: 1cm 2cm 2cm; } ' +
+				'body.document-editor table td > p, div.cke_editable table td > p { margin-top: 0; margin-bottom: 0; padding: 4px 0 3px 5px;} ' +
+				'blockquote { font-family: sans-serif, Arial, Verdana, "Trebuchet MS", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; } ' );
+
 			var editor = CKEDITOR.replace( 'editor', {
 				width: 940,
 				height: 700,

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -166,7 +166,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			CKEDITOR.addCss(
 				'body.document-editor, div.cke_editable { width: 700px; padding: 1cm 2cm 2cm; } ' +
 				'blockquote { font-family: sans-serif, Arial, Verdana, "Trebuchet MS", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; } ' +
-				'body.document-editor table td > p, div.cke_editable table td > p { margin-top: 0; margin-bottom: 0; padding: 4px 0 3px 5px;} ' );
+				'body.document-editor table td > p, div.cke_editable table td > p { margin-top: 0; margin-bottom: 0; padding: 4px 0 3px 5px;} ' +
+				'body.document-editor { width: 750px; padding: 20px; margin: 0.5cm auto; border: 1px #D3D3D3 solid; border-radius: 5px; background: white; box-shadow: 0 0 5px rgba(0, 0, 0, 0.1); }' );
 
 			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 11 ) {
 				var supportInfoEl = document.querySelector( '#browserSupportInfo' );
@@ -195,8 +196,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					{ name: 'document', items: [ 'PageBreak', 'Source' ] }
 				],
 				contentsCss: [
-					CKEDITOR.basePath + 'contents.css',
-					'assets/css/exportpdf.css'
+					CKEDITOR.basePath + 'contents.css'
 				],
 				bodyClass: 'document-editor'
 			} );


### PR DESCRIPTION
I fixed the problem mentioned in the issue besides those connected to stylesheet links.

The protocol issue ( `http` instead of `https` ) is taken from [editor.basePath](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR.html#property-basePath), so it can't be easily changed. The second one (relative path converted to absolute) - I didn't manage to figure out why in the analogous [PfW](https://ckeditor.com/docs/ckeditor4/latest/examples/pastefromword.html) sample it stays the same and here not. But we could just get rid of it - loading necessary styles using `CKEDITOR.addCss()` method as we are already using it anyway (THB I'm not sure why we are using both ways so consolidating it should be a good idea in general).