### PR TITLE
Add info about activating Export to PDF license key

### DIFF
--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -15,9 +15,7 @@ For licensing, see LICENSE.md.
 <info-box info="">
 	This feature is provided through the [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin that is included in `standard` and `full` official CKEditor 4 presets. You can also {@link guide/dev/plugins/README add it to your custom build} with [online builder](https://ckeditor.com/cke4/builder) or download as an [npm package](https://www.npmjs.com/package/ckeditor4-plugin-exportpdf).
 
-	This is a premium feature. Please [contact us](https://ckeditor.com/contact/) if you would like to purchase a license. Let us know if you have any feedback or questions!
-
-	You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).
+	This is a premium feature. Please [contact us](https://ckeditor.com/contact/) if you would like to purchase a license. Let us know if you have any feedback or questions! You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).
 
 	If this feature is used without authentication, the resulting document will be watermarked.
 </info-box>
@@ -73,12 +71,6 @@ As for browser compatibility, the Export to PDF plugin works in all browsers {@l
 The crucial aspect of this feature is its configuration. In order to ensure that the generated PDF looks as close as possible to the same content when it is displayed in the WYSIWYG editor, the feature should be carefully configured. The configuration options available both in the plugin and the HTML to PDF converter allow you to create PDF documents that will fulfill the needs of your application and your end-users.
 
 ### Setting up a license key
-
-<info-box info="">
-	The Export to PDF plugin is a commercial product and a license can be purchased [here](https://ckeditor.com/contact/). You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).
-
-	If this feature is used without authentication, the resulting document will be watermarked.
-</info-box>
 
 There is just one thing you have to do to activate plugin - set a `exportPdf_tokenUrl` configuration option:
 

--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -13,7 +13,7 @@ For licensing, see LICENSE.md.
 # Exporting editor content to PDF
 
 <info-box info="">
-	This feature is provided through the [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin that is included in `standard` and `full` official CKEditor 4 presets. You can also {@link guide/dev/plugins/README add it to your custom build} with [online builder](https://ckeditor.com/cke4/builder) or download as an [npm package](https://www.npmjs.com/package/ckeditor4-plugin-exportpdf).
+	This feature is provided through the [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin that is included in `standard-all` and `full-all` official CKEditor 4 presets. You can also {@link guide/dev/plugins/README add it to your custom build} with [online builder](https://ckeditor.com/cke4/builder) or download as an [npm package](https://www.npmjs.com/package/ckeditor4-plugin-exportpdf).
 
 	This is a premium feature. Please [contact us](https://ckeditor.com/contact/) if you would like to purchase a license. Let us know if you have any feedback or questions! You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).
 
@@ -72,7 +72,7 @@ The crucial aspect of this feature is its configuration. In order to ensure that
 
 ### Setting up a license key
 
-There is just one thing you have to do to activate plugin - set a `exportPdf_tokenUrl` configuration option:
+There is just one thing you have to do to activate Export to PDF plugin - set a `exportPdf_tokenUrl` configuration option:
 
 ```js
 CKEDITOR.replace( 'editor', {
@@ -82,7 +82,7 @@ CKEDITOR.replace( 'editor', {
 
 This value is unique for each customer and can be found in the [CKEditor Ecosystem dashboard](https://dashboard.ckeditor.com).
 
-This is all. If you are having trouble in setting up Easy Image, please [contact us](https://ckeditor.com/contact/).
+This is all. If you are having trouble in setting up Export to PDF, please [contact us](https://ckeditor.com/contact/).
 
 ### Achieving the Best Results
 

--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -70,6 +70,26 @@ As for browser compatibility, the Export to PDF plugin works in all browsers {@l
 
 The crucial aspect of this feature is its configuration. In order to ensure that the generated PDF looks as close as possible to the same content when it is displayed in the WYSIWYG editor, the feature should be carefully configured. The configuration options available both in the plugin and the HTML to PDF converter allow you to create PDF documents that will fulfill the needs of your application and your end-users.
 
+### Setting up a licence key
+
+<info-box info="">
+	The Export to PDF plugin is a commercial product and a license can be purchased [here](https://ckeditor.com/contact/). You can request a <a href="https://orders.ckeditor.com/trial/exportpdf">free trial license key</a> in order to start using it.
+</info-box>
+
+There is just one thing you have to do to activate plugin - set a `exportPdf_tokenUrl` configuration option:
+
+```js
+CKEDITOR.replace( 'editor', {
+	exportPdf_tokenUrl: 'https://example.com/cs-token-endpoint'
+} )
+```
+
+This value is unique for each customer and can be found in the [CKEditor Ecosystem dashboard](https://dashboard.ckeditor.com).
+
+This is all. If you are having trouble in setting up Easy Image, please [contact us](https://ckeditor.com/contact/).
+
+**Note:** Export to PDF plugin can also be tested for free as it is included in `standard` and `full` builds - in such case it is attaching a kind footnote to each generated document.
+
 ### Achieving the Best Results
 
 Due to the differences between browsers and operating systems it is not always possible to reach a perfect match between the content in the editor and in the generated PDF file. However, thanks to flexible configuration, adjusting a few configuration options can make the difference hardly noticeable.

--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -17,7 +17,7 @@ For licensing, see LICENSE.md.
 
 	This is a premium feature. Please [contact us](https://ckeditor.com/contact/) if you would like to purchase a license. Let us know if you have any feedback or questions! You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).
 
-	If this feature is used without authentication, the resulting document will be watermarked.
+	If this feature is used without authorization, the resulting document will be watermarked.
 </info-box>
 
 The optional [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin allows you to easily print the WYSIWYG editor content to a PDF file.
@@ -72,7 +72,7 @@ The crucial aspect of this feature is its configuration. In order to ensure that
 
 ### Setting up a license key
 
-There is just one thing you have to do to activate Export to PDF plugin - set a `exportPdf_tokenUrl` configuration option:
+If you have a commercial license for Export to PDF plugin, [exportPdf_tokenUrl](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-exportPdf_tokenUrl) configuration option should be set to remove watermark from generated documents:
 
 ```js
 CKEDITOR.replace( 'editor', {

--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -13,7 +13,7 @@ For licensing, see LICENSE.md.
 # Exporting editor content to PDF
 
 <info-box info="">
-	This feature is provided through the [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin that is included in `standard-all` and `full-all` official CKEditor 4 presets. You can also {@link guide/dev/plugins/README add it to your custom build} with [online builder](https://ckeditor.com/cke4/builder) or download as an [npm package](https://www.npmjs.com/package/ckeditor4-plugin-exportpdf).
+	This feature is provided through the [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin that is included in `standard-all`, `full` and `full-all` official CKEditor 4 presets. You can also {@link guide/dev/plugins/README add it to your custom build} with [online builder](https://ckeditor.com/cke4/builder) or download as an [npm package](https://www.npmjs.com/package/ckeditor4-plugin-exportpdf).
 
 	This is a premium feature. Please [contact us](https://ckeditor.com/contact/) if you would like to purchase a license. Let us know if you have any feedback or questions! You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).
 

--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -13,9 +13,13 @@ For licensing, see LICENSE.md.
 # Exporting editor content to PDF
 
 <info-box info="">
-	This feature is provided through the [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin that is not included in any official CKEditor 4 preset. You can {@link guide/dev/plugins/README add it to your custom build} with [online builder](https://ckeditor.com/cke4/builder) or download as an [npm package](https://www.npmjs.com/package/ckeditor4-plugin-exportpdf).
+	This feature is provided through the [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin that is included in `standard` and `full` official CKEditor 4 presets. You can also {@link guide/dev/plugins/README add it to your custom build} with [online builder](https://ckeditor.com/cke4/builder) or download as an [npm package](https://www.npmjs.com/package/ckeditor4-plugin-exportpdf).
 
 	This is a premium feature. Please [contact us](https://ckeditor.com/contact/) if you would like to purchase a license. Let us know if you have any feedback or questions!
+
+	You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).
+
+	If this feature is used without authentication, the resulting document will be watermarked.
 </info-box>
 
 The optional [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin allows you to easily print the WYSIWYG editor content to a PDF file.
@@ -71,7 +75,9 @@ The crucial aspect of this feature is its configuration. In order to ensure that
 ### Setting up a licence key
 
 <info-box info="">
-	The Export to PDF plugin is a commercial product and a license can be purchased [here](https://ckeditor.com/contact/). You can request a <a href="https://orders.ckeditor.com/trial/exportpdf">free trial license key</a> in order to start using it.
+	The Export to PDF plugin is a commercial product and a license can be purchased [here](https://ckeditor.com/contact/). You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).
+
+	If this feature is used without authentication, the resulting document will be watermarked.
 </info-box>
 
 There is just one thing you have to do to activate plugin - set a `exportPdf_tokenUrl` configuration option:
@@ -85,8 +91,6 @@ CKEDITOR.replace( 'editor', {
 This value is unique for each customer and can be found in the [CKEditor Ecosystem dashboard](https://dashboard.ckeditor.com).
 
 This is all. If you are having trouble in setting up Easy Image, please [contact us](https://ckeditor.com/contact/).
-
-**Note:** Export to PDF plugin can also be tested for free as it is included in `standard` and `full` builds - in such case it is attaching a kind footnote to each generated document.
 
 ### Achieving the Best Results
 

--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -72,7 +72,7 @@ As for browser compatibility, the Export to PDF plugin works in all browsers {@l
 
 The crucial aspect of this feature is its configuration. In order to ensure that the generated PDF looks as close as possible to the same content when it is displayed in the WYSIWYG editor, the feature should be carefully configured. The configuration options available both in the plugin and the HTML to PDF converter allow you to create PDF documents that will fulfill the needs of your application and your end-users.
 
-### Setting up a licence key
+### Setting up a license key
 
 <info-box info="">
 	The Export to PDF plugin is a commercial product and a license can be purchased [here](https://ckeditor.com/contact/). You can also sign up for the [CKEditor Premium Features 30-day Free Trial](https://orders.ckeditor.com/trial/premium-features).

--- a/docs/features/exporttopdf/README.md
+++ b/docs/features/exporttopdf/README.md
@@ -15,8 +15,6 @@ For licensing, see LICENSE.md.
 <info-box info="">
 	This feature is provided through the [Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin that is not included in any official CKEditor 4 preset. You can {@link guide/dev/plugins/README add it to your custom build} with [online builder](https://ckeditor.com/cke4/builder) or download as an [npm package](https://www.npmjs.com/package/ckeditor4-plugin-exportpdf).
 
-	**This feature is in beta version. It is free to use while in the beta phase.**
-
 	This is a premium feature. Please [contact us](https://ckeditor.com/contact/) if you would like to purchase a license. Let us know if you have any feedback or questions!
 </info-box>
 

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -98,7 +98,7 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 ## exportpdf-no-token
 
 * Location: `plugins/exportpdf/plugin.js`
-* Description: Authentication token for the [CKEditor Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin is empty. The cause of it might be that your {@linkapi CKEDITOR.config.exportPdf_tokenUrl token URL} returned an empty response.
+* Description: The authentication token for the [CKEditor Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin is empty. The cause of it might be that your {@linkapi CKEDITOR.config.exportPdf_tokenUrl token URL} returned an empty response.
 * Additional data: None.
 
 ## exportpdf-no-token-url

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -24,22 +24,22 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 * Description: Incorrect {@linkapi CKEDITOR.config#autoEmbed_widget } value. No widget definition found.
 * Additional data: None.
 
-## cloudservices-no-upload-url
+## cloudservices-no-token
 
 * Location: `plugins/cloudservices/plugin.js`
-* Description: {@linkapi CKEDITOR.config.cloudServices_uploadUrl} configuration variable for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin was not specified.
+* Description: Authentication token for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin is empty. The cause of it might be that your {@linkapi CKEDITOR.config.cloudServices_tokenUrl token URL} returned an empty response.
 * Additional data: None.
 
 ## cloudservices-no-token-url
 
 * Location: `plugins/cloudservices/plugin.js`
-* Description: {@linkapi CKEDITOR.config.cloudServices_tokenUrl} configuration variable for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin was not specified.
+* Description: The {@linkapi CKEDITOR.config.cloudServices_tokenUrl} configuration variable for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin was not specified.
 * Additional data: None.
 
-## cloudservices-no-token
+## cloudservices-no-upload-url
 
 * Location: `plugins/cloudservices/plugin.js`
-* Description: Authentication token for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin is empty. The cause of it might be that your {@linkapi CKEDITOR.config.cloudServices_tokenUrl token URL} returned an empty response.
+* Description: The {@linkapi CKEDITOR.config.cloudServices_uploadUrl} configuration variable for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin was not specified.
 * Additional data: None.
 
 ## editor-destroy-iframe
@@ -68,14 +68,6 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 * Additional data:
 	* `element`: The element's `id` attribute.
 
-## editor-plugin-required
-
-* Location: `core/editor.js`
-* Description: A plugin cannot be removed from the plugins list because it is required by another plugin.
-* Additional data:
-	* `plugin`: The name of the plugin that cannot be removed.
-	* `requiredBy`: The name of the plugin whose requirements block the removal.
-
 ## editor-plugin-conflict
 
 * Location: `core/editor.js`
@@ -83,6 +75,14 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 * Additional data:
 	* `plugin`: The name of the plugin that cannot be initialized.
 	* `replacedWith`: The name of the plugin which has been initialized instead of the conflicting one.
+
+## editor-plugin-required
+
+* Location: `core/editor.js`
+* Description: A plugin cannot be removed from the plugins list because it is required by another plugin.
+* Additional data:
+	* `plugin`: The name of the plugin that cannot be removed.
+	* `requiredBy`: The name of the plugin whose requirements block the removal.
 
 ## embed-no-provider-url
 * Location: `plugins/embed/plugin.js`
@@ -95,16 +95,16 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 * Description: A widget no longer belongs to the current editor's widgets list and is no longer valid.
 * Additional data: None.
 
-## exportpdf-no-token-url
-
-* Location: `plugins/exportpdf/plugin.js`
-* Description: {@linkapi CKEDITOR.config.exportPdf_tokenUrl} configuration variable for the [CKEditor Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin was not specified.
-* Additional data: None.
-
 ## exportpdf-no-token
 
 * Location: `plugins/exportpdf/plugin.js`
 * Description: Authentication token for the [CKEditor Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin is empty. The cause of it might be that your {@linkapi CKEDITOR.config.exportPdf_tokenUrl token URL} returned an empty response.
+* Additional data: None.
+
+## exportpdf-no-token-url
+
+* Location: `plugins/exportpdf/plugin.js`
+* Description: The {@linkapi CKEDITOR.config.exportPdf_tokenUrl} configuration variable for the [CKEditor Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin was not specified.
 * Additional data: None.
 
 ## filetools-response-error
@@ -162,14 +162,14 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 * Description: The selection is no longer fake.
 * Additional data: None.
 
-## uploadimage-config
-
-* Location: `plugins/uploadimage/plugin.js`
-* Description: Upload URL for the Upload Image feature was not defined. Refer to the {@link guide/dev/integration/file_browse_upload/file_upload/README Uploading Dropped or Pasted Files} article for more information.
-* Additional data: None.
-
 ## uploadfile-config
 
 * Location: `plugins/uploadfile/plugin.js`
 * Description: Upload URL for the Upload File feature was not defined. Refer to the {@link guide/dev/integration/file_browse_upload/file_upload/README Uploading Dropped or Pasted Files} article for more information.
+* Additional data: None.
+
+## uploadimage-config
+
+* Location: `plugins/uploadimage/plugin.js`
+* Description: Upload URL for the Upload Image feature was not defined. Refer to the {@link guide/dev/integration/file_browse_upload/file_upload/README Uploading Dropped or Pasted Files} article for more information.
 * Additional data: None.

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -27,7 +27,7 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 ## cloudservices-no-token
 
 * Location: `plugins/cloudservices/plugin.js`
-* Description: Authentication token for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin is empty. The cause of it might be that your {@linkapi CKEDITOR.config.cloudServices_tokenUrl token URL} returned an empty response.
+* Description: The authentication token for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin is empty. The cause of it might be that your {@linkapi CKEDITOR.config.cloudServices_tokenUrl token URL} returned an empty response.
 * Additional data: None.
 
 ## cloudservices-no-token-url

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -171,5 +171,5 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 ## uploadimage-config
 
 * Location: `plugins/uploadimage/plugin.js`
-* Description: Upload URL for the Upload Image feature was not defined. Refer to the {@link guide/dev/integration/file_browse_upload/file_upload/README Uploading Dropped or Pasted Files} article for more information.
+* Description: An upload URL for the Upload Image feature was not defined. Refer to the {@link guide/dev/integration/file_browse_upload/file_upload/README Uploading Dropped or Pasted Files} article for more information.
 * Additional data: None.

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -95,6 +95,18 @@ This article contains the list of CKEditor 4 error codes and their explanation. 
 * Description: A widget no longer belongs to the current editor's widgets list and is no longer valid.
 * Additional data: None.
 
+## exportpdf-no-token-url
+
+* Location: `plugins/exportpdf/plugin.js`
+* Description: {@linkapi CKEDITOR.config.exportPdf_tokenUrl} configuration variable for the [CKEditor Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin was not specified.
+* Additional data: None.
+
+## exportpdf-no-token
+
+* Location: `plugins/exportpdf/plugin.js`
+* Description: Authentication token for the [CKEditor Export to PDF](https://ckeditor.com/cke4/addon/exportpdf) plugin is empty. The cause of it might be that your {@linkapi CKEDITOR.config.exportPdf_tokenUrl token URL} returned an empty response.
+* Additional data: None.
+
 ## filetools-response-error
 
 * Location: `plugins/filetools/plugin.js`

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -53,7 +53,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</p>
 
 		<div class="tip">
-			<p>This is a premium feature. Please <a href="https://ckeditor.com/contact/">contact us</a> if you would like to purchase a license. Let us know if you have any feedback or questions!</p>
+			<p>This is a premium feature. Please <a href="https://ckeditor.com/contact/">contact us</a> if you would like to purchase a license. Let us know if you have any feedback or questions! You can also sign up for the <a href="https://orders.ckeditor.com/trial/premium-features">CKEditor Premium Features 30-day Free Trial</a>.</p>
+			<p>If this feature is used without authentication, the resulting document will be watermarked.</p>
 		</div>
 
 		<p>

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -53,7 +53,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</p>
 
 		<div class="tip">
-			<p><strong>This feature is in beta version. It is free to use while in the beta phase.</strong></p>
 			<p>This is a premium feature. Please <a href="https://ckeditor.com/contact/">contact us</a> if you would like to purchase a license. Let us know if you have any feedback or questions!</p>
 		</div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3078,9 +3078,9 @@
       }
     },
     "ckeditor4-plugin-exportpdf": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ckeditor4-plugin-exportpdf/-/ckeditor4-plugin-exportpdf-0.1.2.tgz",
-      "integrity": "sha512-00LyCWzfEh7ny36kqiuLf0I46koGt4YnAz6F4k0Tntj2B+/XznAT6lE+KuZafOUyqSqJ0DOh5+x1ZQuqpjkIcA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ckeditor4-plugin-exportpdf/-/ckeditor4-plugin-exportpdf-1.0.0.tgz",
+      "integrity": "sha512-3Q6xAQ2Jxf4VQAz6SDgVVxfW/RijJhIdGHrrCti5lpMoD4rSk/McydfchxNkIPyp/WZHZFXhdCg7jeyHiQOXyg=="
     },
     "ckeditor4-plugin-spreadsheet": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chalk": "^2.4.1",
     "cheerio": "^1.0.0-rc.2",
     "ckeditor4-angular": "^1.0.0",
-    "ckeditor4-plugin-exportpdf": "^0.1.2",
+    "ckeditor4-plugin-exportpdf": "^1.0.0",
     "ckeditor4-plugin-spreadsheet": "^1.2.0",
     "ckeditor4-react": "^1.0.0",
     "ckeditor4-vue": "^0.1.0",


### PR DESCRIPTION
This is the point where we should:
* Add info about activating license key (token service URL);
* Remove notes about plugin being in beta version;
* Update info about presets including plugin.

~Currently waiting for the info if the sample should produce docs with or without watermark - I'll update PR if necessary when it gets specified.~ We don't want to get our tokenUrl used by others, so we won't include it.