### PR TITLE
Add support for `@skipsource` annotation for JSDuck

### DIFF
--- a/source/customs.rb
+++ b/source/customs.rb
@@ -36,4 +36,22 @@ module JsDuck::Tag
 			@repeatable = true
 		end
 	end
+
+	class SkipSource < Tag
+		def initialize
+			@tagname = :skipSource
+			@pattern = "skipsource"
+			@repeatable = true
+		end
+
+		def parse_doc(p, pos)
+			{
+				:tagname => :skipSource
+			}
+		end
+
+		def process_doc(h, tags, pos)
+			h[:skipSource] = true
+		end
+	end
 end


### PR DESCRIPTION
We are introducing support for `@skipsource` tag and JSDuck ruby definition is required to handle it properly and attach in output JSON.

How to test?

1.  Switch to this branch.
2.  Replace `node_modules/umberto` with dev version of `umberto` (just check out our repo there) and switch to feature branch.
3.  Run `npm i` inside `node_modules/umberto`.
4.  Add `@skipsource` annotation to any api docs (any config, event, etc) in your local `ckeditor4` repo copy.
5.  Build docs.

There should be no warnings about unsupported tag during build and marked API item should not have `See source` link.

:point\_up: **The above tests entire workflow which I already checked so quicker way is to just**:

1.  Add `@skipsource` annotation to any api docs (any config, event, etc) in your local `ckeditor4` repo copy.
2.  Build docs.
3.  Check `docs/api/data` folder and corresponding `json` file to see if `skipSource: true` property is there.