### PR TITLE
Update Angular docs and samples after removing 'divarea' editor type

### DIFF
--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -68,7 +68,7 @@ Alternatively, you can load CKEditor before loading the CKEditor 4 Angular compo
 
 ## Choosing the Editor Type
 
-By default, starting from stable `1.0.0` version, the CKEditor 4 Angular component creates a {@link guide/dev/framed/README classic editor}. You can easily switch to an {@link guide/dev/inline/README inline editor} with a {@link features/uitypes/README#fixed-ui-for-inline-editor fixed UI} (which was the default one for integration beta versions) by setting component `type` property to `divarea`. To create an editor with a {@link features/uitypes/README#floating-user-interface floating UI}, change the `type` property to `inline`:
+By default, starting from stable `1.0.0` version, the CKEditor 4 Angular component creates a {@link guide/dev/framed/README classic editor}. To create an editor with a {@link features/uitypes/README#floating-user-interface floating UI}, change the `type` property to `inline`:
 
 ```html
 <ckeditor
@@ -77,14 +77,7 @@ By default, starting from stable `1.0.0` version, the CKEditor 4 Angular compone
 ></ckeditor>
 ```
 
-So there are 3 possible values for the `type` property:
-
-* `classic` (default)
-* `divarea`
-* `inline`
-
-Notes:
-* The [Div Editing Area plugin](https://ckeditor.com/cke4/addon/divarea) must be {@link guide/dev/plugins/README included in your editor build} to use `divarea` editor type. In this case, however, there is no need to list it in the {@linkapi CKEDITOR.config#plugins `config.plugins`} or {@linkapi CKEDITOR.config#extraPlugins `config.extraPlugins`} options as the Angular component does this automatically for you.
+Up to the integration version `1.3.0` there was also a separate `divarea` editor type - an {@link guide/dev/inline/README inline editor} with a {@link features/uitypes/README#fixed-ui-for-inline-editor fixed UI}. From the `2.0.0` it is still available, but instead of setting the editor type you just need to include a [Div Editing Area plugin](https://ckeditor.com/cke4/addon/divarea) in the editor config.
 
 ## Integration with ngModel
 
@@ -104,7 +97,7 @@ export class MyComponent {
 }
 ```
 
-Then you can use the model in the template to enable the two-way binding.
+Then you can use the model in the template to enable the two-way data binding.
 
 ```html
 <ckeditor [(ngModel)]="model.editorData"></ckeditor>
@@ -129,7 +122,7 @@ Custom configuration can be passed to the editor with the `config` attribute pas
 ></ckeditor>
 ```
 
-{@linkapi CKEDITOR.config All configuration} options can be changed this way.
+All {@linkapi CKEDITOR.config configuration options} can be changed this way.
 
 ### `data`
 
@@ -159,6 +152,7 @@ export class MyComponent {
 Specifies the tag name of the HTML element on which the WYSIWYG editor will be created.
 
 The default tag is `<textarea>`.
+
 ``` html
 <ckeditor tagName="textarea"></ckeditor>
 ```
@@ -223,7 +217,7 @@ Fires when the editor's editable is focused. It corresponds with the {@linkapi C
 
 ### `blur`
 
-Fires when the editing view of the editor is blurred. It corresponds with the {@linkapi CKEDITOR.editor#blur `editor#blur`} event.
+Fires when the editing area of the editor is blurred. It corresponds with the {@linkapi CKEDITOR.editor#blur `editor#blur`} event.
 
 ### `paste`
 
@@ -269,8 +263,8 @@ Please note that this property is initialised asynchronously, when the component
 
 ## Types
 
-CKEditor types can be installed from [@types/ckeditor](https://www.npmjs.com/package/@types/ckeditor). Note that they are not maintained by the CKEditor team, so we cannot guarantee that they are up to date.
+CKEditor 4 types can be installed from [@types/ckeditor](https://www.npmjs.com/package/@types/ckeditor). Note that they are not maintained by the CKEditor team, so we cannot guarantee that they are up to date.
 
 ## CKEditor 4 Angular Integration Demo
 
-See the {@linkexample angular working "CKEditor 4 Angular Integration" sample} that showcases the most iomportant features of the integration, including choosing the editor type, configuration and events, or setting up two-way data binding.
+See the {@linkexample angular working "CKEditor 4 Angular Integration" sample} that showcases the most important features of the integration, including switching the editor type, configuration and events, or setting up two-way data binding.

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -91,7 +91,7 @@ To use the `divarea` editor in `2.0.0` and later versions, you just need to incl
 ></ckeditor>
 ```
 
-To use the `divarea` editor in versions prior `2.0.0` (up to `1.3.0`), you have to change editor type to `divarea`:
+To use the `divarea` editor in versions prior `2.0.0` (up to `1.3.0`), you have to change the editor type to `divarea`:
 
 ```html
 <ckeditor

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -77,7 +77,28 @@ By default, starting from stable `1.0.0` version, the CKEditor 4 Angular compone
 ></ckeditor>
 ```
 
-Up to the integration version `1.3.0` there was also a separate `divarea` editor type - an {@link guide/dev/inline/README inline editor} with a {@link features/uitypes/README#fixed-ui-for-inline-editor fixed UI}. From the `2.0.0` it is still available, but instead of setting the editor type you just need to include a [Div Editing Area plugin](https://ckeditor.com/cke4/addon/divarea) in the editor config.
+### Using Div Area Editor Type
+
+Before [`2.0.0` integration version](https://www.npmjs.com/package/ckeditor4-angular/v/2.0.0) there was also a separate `divarea` editor type (an {@link guide/dev/inline/README inline editor} with a {@link features/uitypes/README#fixed-ui-for-inline-editor fixed UI}).
+
+To use `divarea` editor in `2.0.0` and later versions you just need to include a [Div Editing Area plugin](https://ckeditor.com/cke4/addon/divarea) in the editor config:
+
+```html
+<ckeditor
+	data="<p>Some initial data</p>"
+	type="inline"
+	[config]="{ extraPlugins: 'divarea' }">
+></ckeditor>
+```
+
+To use `divarea` editor in versions before `2.0.0` (up to `1.3.0`), you have to change editor type to `divarea`:
+
+```html
+<ckeditor
+	data="<p>Some initial data</p>"
+	type="divarea"
+></ckeditor>
+```
 
 ## Integration with ngModel
 

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -81,7 +81,7 @@ By default, starting from the stable `1.0.0` version, the CKEditor 4 Angular com
 
 Before the [`2.0.0` integration version](https://www.npmjs.com/package/ckeditor4-angular/v/2.0.0) there was also a separate `divarea` editor type (an {@link guide/dev/inline/README inline editor} with a {@link features/uitypes/README#fixed-ui-for-inline-editor fixed UI}).
 
-To use the `divarea` editor in `2.0.0` and later versions you just need to include a [Div Editing Area plugin](https://ckeditor.com/cke4/addon/divarea) in the editor config:
+To use the `divarea` editor in `2.0.0` and later versions, you just need to include the [Div Editing Area](https://ckeditor.com/cke4/addon/divarea) plugin in the editor configuration:
 
 ```html
 <ckeditor

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -68,7 +68,7 @@ Alternatively, you can load CKEditor before loading the CKEditor 4 Angular compo
 
 ## Choosing the Editor Type
 
-By default, starting from stable `1.0.0` version, the CKEditor 4 Angular component creates a {@link guide/dev/framed/README classic editor}. To create an editor with a {@link features/uitypes/README#floating-user-interface floating UI}, change the `type` property to `inline`:
+By default, starting from the stable `1.0.0` version, the CKEditor 4 Angular component creates a {@link guide/dev/framed/README classic editor}. To create an editor with a {@link features/uitypes/README#floating-user-interface floating UI}, change the `type` property to `inline`:
 
 ```html
 <ckeditor
@@ -79,9 +79,9 @@ By default, starting from stable `1.0.0` version, the CKEditor 4 Angular compone
 
 ### Using Div Area Editor Type
 
-Before [`2.0.0` integration version](https://www.npmjs.com/package/ckeditor4-angular/v/2.0.0) there was also a separate `divarea` editor type (an {@link guide/dev/inline/README inline editor} with a {@link features/uitypes/README#fixed-ui-for-inline-editor fixed UI}).
+Before the [`2.0.0` integration version](https://www.npmjs.com/package/ckeditor4-angular/v/2.0.0) there was also a separate `divarea` editor type (an {@link guide/dev/inline/README inline editor} with a {@link features/uitypes/README#fixed-ui-for-inline-editor fixed UI}).
 
-To use `divarea` editor in `2.0.0` and later versions you just need to include a [Div Editing Area plugin](https://ckeditor.com/cke4/addon/divarea) in the editor config:
+To use the `divarea` editor in `2.0.0` and later versions you just need to include a [Div Editing Area plugin](https://ckeditor.com/cke4/addon/divarea) in the editor config:
 
 ```html
 <ckeditor
@@ -91,7 +91,7 @@ To use `divarea` editor in `2.0.0` and later versions you just need to include a
 ></ckeditor>
 ```
 
-To use `divarea` editor in versions before `2.0.0` (up to `1.3.0`), you have to change editor type to `divarea`:
+To use the `divarea` editor in versions prior `2.0.0` (up to `1.3.0`), you have to change editor type to `divarea`:
 
 ```html
 <ckeditor
@@ -134,7 +134,7 @@ The URL address to `ckeditor.js`. Refer to [Customising CKEditor Preset or Versi
 
 ### `config`
 
-Custom configuration can be passed to the editor with the `config` attribute passed to `<ckeditor>` in the component template. The following example shows {@link features/toolbar/README how to change the toolbar configuration}:
+Custom configuration can be passed to the editor with the `config` attribute passed to the `<ckeditor>` in the component template. The following example shows {@link features/toolbar/README how to change the toolbar configuration}:
 
 ```html
 <ckeditor
@@ -180,7 +180,7 @@ The default tag is `<textarea>`.
 
 ### `readOnly`
 
-The editor can be set to {@link features/readonly/README read-only mode} with the `readOnly` property:
+The editor can be set to a {@link features/readonly/README read-only mode} with the `readOnly` property:
 
 ```html
 <ckeditor

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -77,7 +77,7 @@ By default, starting from the stable `1.0.0` version, the CKEditor 4 Angular com
 ></ckeditor>
 ```
 
-### Using Div Area Editor Type
+### Using the Div-based Editor Type
 
 Before the [`2.0.0` integration version](https://www.npmjs.com/package/ckeditor4-angular/v/2.0.0) there was also a separate `divarea` editor type (an {@link guide/dev/inline/README inline editor} with a {@link features/uitypes/README#fixed-ui-for-inline-editor fixed UI}).
 

--- a/docs/sdk/examples/angular.html
+++ b/docs/sdk/examples/angular.html
@@ -8,7 +8,7 @@ For licensing, see license.html or https://sdk.ckeditor.com/license.html.
 	<meta charset="utf-8">
 	<meta name="description" content="CKEditor 4 WYSIWYG editor Angular framework integration. Using CKEditor 4 as an Angular component.">
 	<meta name="keywords" content="ckeditor, editor, wysiwyg, angular, integration">
-	<meta name="sdk-samples" content="Editor types|Component events and Angular directives|Form example">
+	<meta name="sdk-samples" content="Classic Editor|Inline Editor|Component events and Angular directives|Integration with forms">
 	<meta name="sdk-category" content="sdk-framework-integration">
 	<meta name="sdk-order" content="10">
 	<title>Angular Integration</title>
@@ -172,7 +172,7 @@ For licensing, see license.html or https://sdk.ckeditor.com/license.html.
 		</h1>
 
 		<p>
-			The <strong>Angular 5+ integration</strong> allows you to implement CKEditor 4 as an <a href="https://angular.io/">Angular</a> component, using the <code>&lt;ckeditor&gt;</code> tag.
+			The <strong>Angular 5+ integration</strong> allows you to implement CKEditor 4 as an <a href="https://angular.io/">Angular</a> component, using the <code>&lt;ckeditor /&gt;</code> tag.
 		</p>
 
 		<p>
@@ -194,266 +194,229 @@ For licensing, see license.html or https://sdk.ckeditor.com/license.html.
 
 <script type="text/jsx" data-sample="1" data-sample-preserve-whitespace data-sample-strip-outer-tag
 		data-sample-template="empty" data-sample-highlighter="typescript">
-	import { Component } from '@angular/core';
+import { Component } from '@angular/core';
 
-	@Component( {
-		selector: 'app-editor-types',
-		template: `
-			<h2>{{ type }} Editor</h2>
-
-			<p>
-				To use the CKEditor 4 WYSIWYG editor component, create a new <code>&lt;ckeditor&gt;</code> tag. The initial data of the editor can be set with the <code>data</code> property.
-			</p>
-
-			<p>
-				Three available editor types are <strong>classic editor</strong> (default one), <strong>divarea editor</strong> (an inline editor with a <a href="./fixedui.html">fixed UI</a>) and <strong>inline editor</strong> with a <a href="./floatingui.html">floating UI</a>.
-			</p>
-
-			<p>Use the select below to change the editor type.</p>
-
-			<ckeditor
-				*ngIf="!inline && !divarea"
-				[(data)]="editorData">
-			</ckeditor>
-
-			<ckeditor
-				*ngIf="divarea"
-				type="divarea"
-				[(data)]="editorData">
-			</ckeditor>
-
-			<ckeditor
-				*ngIf="inline"
-				type="inline"
-				[(data)]="editorData">
-			</ckeditor>
-
-			<div class="select-editor-type">
-				<label for="editor-type">Choose editor type:</label>
-
-				<select id="editor-type" class="editor-type" (change)="onChange($event.target.value)">
-					<option value="classic">Classic Editor</option>
-					<option value="divarea">Divarea Editor</option>
-					<option value="inline">Inline Editor</option>
-				</select>
-			</div>
-		`
-	} )
-
-	export class EditorTypesComponent {
-		public isReadOnly = false;
-		public editorData =
-			`<p>This is a CKEditor 4 instance created with Angular.</p>`;
-
-		public type = 'Classic';
-		public inline = false;
-		public divarea = false;
-
-		public componentEvents: string[] = [];
-
-		onChange( newValue ) {
-			this.inline = newValue === 'inline';
-			this.divarea = newValue === 'divarea';
-
-			this.type = newValue.charAt( 0 ).toUpperCase() + newValue.substring( 1 );
-		}
-	}
+@Component( {
+	selector: 'app-classic-editor',
+	template: `
+		<ckeditor
+			[(data)]="editorData">
+		</ckeditor>
+	`
+} )
+export class ClassicEditorComponent {
+	public editorData = `<p>This is a CKEditor 4 instance created with Angular.</p>`;
+}
 </script>
+
 <script type="text/jsx" data-sample="2" data-sample-preserve-whitespace data-sample-strip-outer-tag
 		data-sample-template="empty" data-sample-highlighter="typescript">
-	import { Component } from '@angular/core';
+import { Component } from '@angular/core';
 
-	interface ComponentEvent {
-		name: string;
-		counter: number;
-		message: string;
-	}
-
-	@Component( {
-		selector: 'app-events',
-		template: `
-			<h2>Events and Directives</h2>
-
-			<p>
-				The CKEditor 4 WYSIWYG editor component allows you to bind event handlers with <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html#supported-output-properties"><code>@Output</code></a> attributes in the HTML code.
-			</p>
-
-			<p>
-				The following example shows how to bind several CKEditor events. Additionally, it presents how the component could be used with <a href="https://angular.io/guide/attribute-directives">Angular directives</a>.
-			</p>
-
-			<ckeditor
-				*ngIf="!isRemoved"
-				data="<p>This is a CKEditor 4 instance created with Angular.</p>"
-				[readOnly]="isReadOnly"
-				[hidden]="isHidden"
-
-				(ready)="onReady()"
-				(change)="onChange()"
-				(focus)="onFocus()"
-				(blur)="onBlur()">
-			</ckeditor>
-
-			<h3>Events log</h3>
-
-			<ul class="events-log">
-				<li *ngFor="let event of componentEvents">{{ event.message }}>
-					<span *ngIf="event.counter > 1"> ({{ event.counter }})</span>
-				</li>
-			</ul>
-
-			<button (click)="clearEventsLog()">Clear events log</button>
-
-			<h3>Angular directives</h3>
-
-			<p><label><input type="checkbox" [(ngModel)]="isHidden">Hide the editor with the <code>[hidden]</code> directive.</label></p>
-			<p><label><input type="checkbox" [(ngModel)]="isRemoved">Remove the editor from DOM with the <code>*ngIf</code> directive.</label></p>
-			<p><label><input type="checkbox" [(ngModel)]="isReadOnly">Make the editor read-only.</label></p>
-		`
-	} )
-
-	export class EventsComponent {
-		public isReadOnly = false;
-
-		public isHidden = false;
-
-		public isRemoved = false;
-
-		public componentEvents: ComponentEvent[] = [];
-
-		clearEventsLog(): void {
-			this.componentEvents.length = 0;
-		}
-
-		onReady(): void {
-			this.saveEvent( 'ready' );
-		}
-
-		onChange(): void {
-			this.saveEvent( 'changed' );
-		}
-
-		onFocus(): void {
-			this.saveEvent( 'focused' );
-		}
-
-		onBlur(): void {
-			this.saveEvent( 'blurred' );
-		}
-
-		private saveEvent( eventName: string ): void {
-			const events = this.componentEvents;
-			let message = `Editor ${ eventName === 'changed' ? 'has' : 'is' } ${ eventName }`;
-
-			if ( events.length && events[ 0 ].name === eventName ) {
-				events[ 0 ].counter++;
-			} else {
-				events.unshift( {
-					name: eventName,
-					counter: 1,
-					message: message
-				} );
-			}
-		}
-	}
+@Component( {
+	selector: 'app-inline-editor',
+	template: `
+		<ckeditor
+			type="inline"
+			[(data)]="editorData">
+		</ckeditor>
+	`
+} )
+export class InlineEditorComponent {
+	public editorData = `<p>This is a CKEditor 4 instance created with Angular.</p>`;
+}
 </script>
+
 <script type="text/jsx" data-sample="3" data-sample-preserve-whitespace data-sample-strip-outer-tag
 		data-sample-template="empty" data-sample-highlighter="typescript">
+import { Component } from '@angular/core';
 
-	import {
-		Component,
-		ViewChild,
-		AfterViewInit,
-		ElementRef
-	} from '@angular/core';
+interface ComponentEvent {
+	name: string;
+	counter: number;
+	message: string;
+}
 
-	import { NgForm } from '@angular/forms';
+@Component( {
+	selector: 'app-events',
+	template: `
+		<h2>Events and Directives</h2>
 
-	@Component( {
-		selector: 'app-demo-form',
-		template: `
-			<h2>Integration with forms (<code>ngModel</code>)</h2>
+		<p>
+			The CKEditor 4 WYSIWYG editor component allows you to bind event handlers with <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html#supported-output-properties"><code>@Output</code></a> attributes in the HTML code.
+		</p>
 
-			<p>
-				The CKEditor 4 WYSIWYG editor component implements the <a href="https://angular.io/api/forms/ControlValueAccessor"><code>ControlValueAccessor</code> interface</a> and works with <code>ngModel</code>. For example, it can be used to integrate with a simple form like the one below.
-			</p>
+		<p>
+			The following example shows how to bind several CKEditor events. Additionally, it presents how the component could be used with <a href="https://angular.io/guide/attribute-directives">Angular directives</a>.
+		</p>
 
-			<form (ngSubmit)="onSubmit()" #demoForm="ngForm">
-				<h3>User profile form</h3>
+		<ckeditor
+			*ngIf="!isRemoved"
+			data="<p>This is a CKEditor 4 instance created with Angular.</p>"
+			[readOnly]="isReadOnly"
+			[hidden]="isHidden"
 
-				<div>
-					<label for="name">Name</label>
-					<input [(ngModel)]="model.name" type="text" name="name" id="name">
-				</div>
+			(ready)="onReady()"
+			(change)="onChange()"
+			(focus)="onFocus()"
+			(blur)="onBlur()">
+		</ckeditor>
 
-				<div>
-					<label for="surname">Surname</label>
-					<input [(ngModel)]="model.surname" type="text" name="surname" id="surname">
-				</div>
+		<h3>Events log</h3>
 
-				<label for="description">Description</label>
-				<ckeditor
-					#editor
-					[(ngModel)]="model.description"
-					id="description"
-					name="description"
-					type="divarea">
-				</ckeditor>
+		<ul class="events-log">
+			<li *ngFor="let event of componentEvents">{{ event.message }}>
+				<span *ngIf="event.counter > 1"> ({{ event.counter }})</span>
+			</li>
+		</ul>
 
-				<p><button type="reset" (click)="reset()">Reset form</button></p>
-				<p><button type="submit">Submit this form</button></p>
-			</form>
+		<button (click)="clearEventsLog()">Clear events log</button>
 
-			<h3>Editor data preview</h3>
-			<p>
-				Note that this is only a proof of concept of using <code>ngModel</code>.
-				It allows for editing the form, but the editor strips out unknown tags. It also autoparagraphs text outside of block
-				elements. The editor updates when the textarea element is blurred.
-			</p>
+		<h3>Angular directives</h3>
 
-			<textarea #preview
-				(focus)="isPreviewActive = true; previewModel = model.description"
-				(change)="isPreviewActive = false; model.description = previewModel"
-				[(ngModel)]="previewModel"></textarea>
-		`,
-		styleUrls: [ './demo-form.component.css' ]
-	} )
+		<p><label><input type="checkbox" [(ngModel)]="isHidden">Hide the editor with the <code>[hidden]</code> directive.</label></p>
+		<p><label><input type="checkbox" [(ngModel)]="isRemoved">Remove the editor from DOM with the <code>*ngIf</code> directive.</label></p>
+		<p><label><input type="checkbox" [(ngModel)]="isReadOnly">Make the editor read-only.</label></p>
+	`
+} )
+export class EventsComponent {
+	public isReadOnly = false;
+	public isHidden = false;
+	public isRemoved = false;
+	public componentEvents: ComponentEvent[] = [];
 
-	export class DemoFormComponent implements AfterViewInit {
-		@ViewChild( 'demoForm' ) demoForm?: NgForm;
-		@ViewChild( 'preview' ) preview: ElementRef;
-		@ViewChild( 'editor' ) editor;
+	clearEventsLog(): void {
+		this.componentEvents.length = 0;
+	}
 
-		public model = {
-			name: 'John',
-			surname: 'Doe',
-			description: '<p>This is a sample form using CKEditor 4 and created in Angular.</p>'
-		};
+	onReady(): void {
+		this.saveEvent( 'ready' );
+	}
 
-		public isPreviewActive: boolean;
+	onChange(): void {
+		this.saveEvent( 'changed' );
+	}
 
-		public previewModel: string;
+	onFocus(): void {
+		this.saveEvent( 'focused' );
+	}
 
-		onSubmit() {
-			alert( `Form submit, model: ${ JSON.stringify( this.model ) }` );
-		}
+	onBlur(): void {
+		this.saveEvent( 'blurred' );
+	}
 
-		reset() {
-			this.demoForm!.reset();
-		}
+	private saveEvent( eventName: string ): void {
+		const events = this.componentEvents;
+		let message = `Editor ${ eventName === 'changed' ? 'has' : 'is' } ${ eventName }`;
 
-		get description() {
-			return this.demoForm!.controls.description;
-		}
-
-		ngAfterViewInit() {
-			this.editor.dataChange.subscribe( ( value ) => {
-				if ( !this.isPreviewActive ) {
-					this.previewModel = value;
-				}
+		if ( events.length && events[ 0 ].name === eventName ) {
+			events[ 0 ].counter++;
+		} else {
+			events.unshift( {
+				name: eventName,
+				counter: 1,
+				message: message
 			} );
 		}
 	}
+}
+</script>
+
+<script type="text/jsx" data-sample="4" data-sample-preserve-whitespace data-sample-strip-outer-tag
+		data-sample-template="empty" data-sample-highlighter="typescript">
+import {
+	Component,
+	ViewChild,
+	AfterViewInit,
+	ElementRef
+} from '@angular/core';
+
+import { NgForm } from '@angular/forms';
+
+@Component( {
+	selector: 'app-demo-form',
+	template: `
+		<h2>Integration with forms (<code>ngModel</code>)</h2>
+
+		<p>
+			The CKEditor 4 WYSIWYG editor component implements the <a href="https://angular.io/api/forms/ControlValueAccessor"><code>ControlValueAccessor</code> interface</a> and works with <code>ngModel</code>. For example, it can be used to integrate with a simple form like the one below.
+		</p>
+
+		<form (ngSubmit)="onSubmit()" #demoForm="ngForm">
+			<h3>User profile form</h3>
+
+			<div>
+				<label for="name">Name</label>
+				<input [(ngModel)]="model.name" type="text" name="name" id="name">
+			</div>
+
+			<div>
+				<label for="surname">Surname</label>
+				<input [(ngModel)]="model.surname" type="text" name="surname" id="surname">
+			</div>
+
+			<label for="description">Description</label>
+			<ckeditor
+				#editor
+				[(ngModel)]="model.description"
+				id="description"
+				name="description"
+				type="divarea">
+			</ckeditor>
+
+			<p><button type="reset" (click)="reset()">Reset form</button></p>
+			<p><button type="submit">Submit this form</button></p>
+		</form>
+
+		<h3>Editor data preview</h3>
+		<p>
+			Note that this is only a proof of concept of using <code>ngModel</code>.
+			It allows for editing the form, but the editor strips out unknown tags. It also autoparagraphs text outside of block
+			elements. The editor updates when the textarea element is blurred.
+		</p>
+
+		<textarea #preview
+			(focus)="isPreviewActive = true; previewModel = model.description"
+			(change)="isPreviewActive = false; model.description = previewModel"
+			[(ngModel)]="previewModel"></textarea>
+	`,
+	styleUrls: [ './demo-form.component.css' ]
+} )
+export class DemoFormComponent implements AfterViewInit {
+	@ViewChild( 'demoForm' ) demoForm?: NgForm;
+	@ViewChild( 'preview' ) preview: ElementRef;
+	@ViewChild( 'editor' ) editor;
+
+	public model = {
+		name: 'John',
+		surname: 'Doe',
+		description: '<p>This is a sample form using CKEditor 4 and created in Angular.</p>'
+	};
+
+	public isPreviewActive: boolean;
+
+	public previewModel: string;
+
+	onSubmit() {
+		alert( `Form submit, model: ${ JSON.stringify( this.model ) }` );
+	}
+
+	reset() {
+		this.demoForm!.reset();
+	}
+
+	get description() {
+		return this.demoForm!.controls.description;
+	}
+
+	ngAfterViewInit() {
+		this.editor.dataChange.subscribe( ( value ) => {
+			if ( !this.isPreviewActive ) {
+				this.previewModel = value;
+			}
+		} );
+	}
+}
 </script>
 
 </body>

--- a/docs/sdk/examples/angular.html
+++ b/docs/sdk/examples/angular.html
@@ -275,7 +275,7 @@ interface ComponentEvent {
 		<h3>Angular directives</h3>
 
 		<p><label><input type="checkbox" [(ngModel)]="isHidden">Hide the editor with the <code>[hidden]</code> directive.</label></p>
-		<p><label><input type="checkbox" [(ngModel)]="isRemoved">Remove the editor from DOM with the <code>*ngIf</code> directive.</label></p>
+		<p><label><input type="checkbox" [(ngModel)]="isRemoved">Remove the editor from the DOM with the <code>*ngIf</code> directive.</label></p>
 		<p><label><input type="checkbox" [(ngModel)]="isReadOnly">Make the editor read-only.</label></p>
 	`
 } )

--- a/docs/sdk/examples/angular.html
+++ b/docs/sdk/examples/angular.html
@@ -243,11 +243,11 @@ interface ComponentEvent {
 		<h2>Events and Directives</h2>
 
 		<p>
-			The CKEditor 4 WYSIWYG editor component allows you to bind event handlers with <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html#supported-output-properties"><code>@Output</code></a> attributes in the HTML code.
+			The CKEditor 4 WYSIWYG editor component allows you to bind event handlers with the <a href="https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html#supported-output-properties"><code>@Output</code></a> attributes in the HTML code.
 		</p>
 
 		<p>
-			The following example shows how to bind several CKEditor events. Additionally, it presents how the component could be used with <a href="https://angular.io/guide/attribute-directives">Angular directives</a>.
+			The following example shows how to bind several CKEditor 4 events. Additionally, it presents how the component could be used with the <a href="https://angular.io/guide/attribute-directives">Angular directives</a>.
 		</p>
 
 		<ckeditor
@@ -370,8 +370,8 @@ import { NgForm } from '@angular/forms';
 
 		<h3>Editor data preview</h3>
 		<p>
-			Note that this is only a proof of concept of using <code>ngModel</code>.
-			It allows for editing the form, but the editor strips out unknown tags. It also autoparagraphs text outside of block
+			Note that this is only a proof of concept of using the <code>ngModel</code>.
+			It allows for editing the form, but the editor strips out unknown tags. It also autoparagraphs the text outside of block
 			elements. The editor updates when the textarea element is blurred.
 		</p>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3069,12 +3069,19 @@
       "integrity": "sha512-oC7/DVAyfcY3UWKm0sN/oVoDedQDQiw/vIiAnuTWTpE5s0zWf7l3WY417Xw/Fbi/QbAjctAkxgMiS9P0s3zkmA=="
     },
     "ckeditor4-angular": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ckeditor4-angular/-/ckeditor4-angular-1.3.0.tgz",
-      "integrity": "sha512-+xWaI0fKIWq0V3ItWikgkgoWjpijF1g/rVgkueZCVWA9aVw7dDUdA+wlQ48yDbZeb3ODrdIZqDnyqnD8mIXM4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ckeditor4-angular/-/ckeditor4-angular-2.0.0.tgz",
+      "integrity": "sha512-2dg7faS+KzOhqexOOr5+CEG9v8bhVxCOHnMKLn1GXRVK//Z62ltHx56InJa9k3jQRHeDlIcUhqCP9Yv+sehXAA==",
       "requires": {
         "load-script": "^1.0.0",
-        "tslib": "^1.9.0"
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+        }
       }
     },
     "ckeditor4-plugin-spreadsheet": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-loader": "^8.0.4",
     "chalk": "^2.4.1",
     "cheerio": "^1.0.0-rc.2",
-    "ckeditor4-angular": "^1.3.0",
+    "ckeditor4-angular": "^2.0.0",
     "ckeditor4-plugin-spreadsheet": "^1.2.0",
     "ckeditor4-react": "^1.2.0",
     "ckeditor4-vue": "^1.1.0",

--- a/scripts/integrations/angular/src/app/demo-form/demo-form.component.html
+++ b/scripts/integrations/angular/src/app/demo-form/demo-form.component.html
@@ -20,8 +20,7 @@
 		#editor
 		[(ngModel)]="model.description"
 		id="description"
-		name="description"
-		type="divarea">
+		name="description">
 	</ckeditor>
 
 	<p class="demo-form__controls">

--- a/scripts/integrations/angular/src/app/demo-form/demo-form.component.html
+++ b/scripts/integrations/angular/src/app/demo-form/demo-form.component.html
@@ -31,8 +31,8 @@
 
 <h3>Editor data preview</h3>
 <p>
-	Note that this is only a proof of concept of using <code>ngModel</code>.
-	It allows for editing the form, but the editor strips out unknown tags. It also autoparagraphs text outside of block
+	Note that this is only a proof of concept of using the <code>ngModel</code>.
+	It allows for editing the form, but the editor strips out unknown tags. It also autoparagraphs the text outside of block
 	elements. The editor updates when the textarea element is blurred.
 </p>
 <textarea class="editor-preview" #preview

--- a/scripts/integrations/angular/src/app/editor-types/editor-types.component.html
+++ b/scripts/integrations/angular/src/app/editor-types/editor-types.component.html
@@ -1,38 +1,20 @@
-<h2>{{ type }} Editor</h2>
+<h2>Classic WYSIWYG Editor</h2>
 
 <p>
-	To use the CKEditor 4 WYSIWYG editor component, create a new <code>&lt;ckeditor&gt;</code> tag. The initial data of the editor can be set with the <code>data</code> property.
+	To use the CKEditor 4 <a href="./classic.html">classic editor</a> in Angular, create a new <code>&lt;ckeditor /&gt;</code> tag. The initial data of the editor can be set with the <code>data</code> property.
 </p>
-
-<p>
-	Three available editor types are <strong>classic editor</strong> (default one), <strong>divarea editor</strong> (an inline editor with a <a href="./fixedui.html">fixed UI</a>) and <strong>inline editor</strong> with a <a href="./floatingui.html">floating UI</a>.
-</p>
-
-<p>Use the select below to change the editor type.</p>
 
 <ckeditor
-	*ngIf="!inline && !divarea"
 	[(data)]="editorData">
 </ckeditor>
 
-<ckeditor
-	*ngIf="divarea"
-	type="divarea"
-	[(data)]="editorData">
-</ckeditor>
+<h2>Inline WYSIWYG Editor</h2>
+
+<p>
+	To use the CKEditor 4 <a href="./inline.html">inline editor</a> in Angular, set the <code>type</code> property of <code>&lt;ckeditor /&gt;</code> element to <code>inline</code>.
+</p>
 
 <ckeditor
-	*ngIf="inline"
 	type="inline"
 	[(data)]="editorData">
 </ckeditor>
-
-<div class="select-editor-type">
-	<label for="editor-type">Choose editor type:</label>
-
-	<select id="editor-type" class="editor-type" (change)="onChange($event.target.value)">
-		<option value="classic">Classic Editor</option>
-		<option value="divarea">Divarea Editor</option>
-		<option value="inline">Inline Editor</option>
-	</select>
-</div>

--- a/scripts/integrations/angular/src/app/editor-types/editor-types.component.html
+++ b/scripts/integrations/angular/src/app/editor-types/editor-types.component.html
@@ -11,7 +11,7 @@
 <h2>Inline WYSIWYG Editor</h2>
 
 <p>
-	To use the CKEditor 4 <a href="./inline.html">inline editor</a> in Angular, set the <code>type</code> property of <code>&lt;ckeditor /&gt;</code> element to <code>inline</code>.
+	To use the CKEditor 4 <a href="./inline.html">inline editor</a> in Angular, set the <code>type</code> property of the <code>&lt;ckeditor /&gt;</code> element to <code>inline</code>.
 </p>
 
 <ckeditor

--- a/scripts/integrations/angular/src/app/editor-types/editor-types.component.ts
+++ b/scripts/integrations/angular/src/app/editor-types/editor-types.component.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md.
  */
 
@@ -10,20 +10,5 @@ import { Component } from '@angular/core';
 	templateUrl: './editor-types.component.html'
 } )
 export class EditorTypesComponent {
-	public isReadOnly = false;
-	public editorData =
-		`<p>This is a CKEditor 4 instance created with Angular.</p>`;
-
-	public type = 'Classic';
-	public inline = false;
-	public divarea = false;
-
-	public componentEvents: string[] = [];
-
-	onChange( newValue ) {
-		this.inline = newValue === 'inline';
-		this.divarea = newValue === 'divarea';
-
-		this.type = newValue.charAt( 0 ).toUpperCase() + newValue.substring( 1 );
-	}
+	public editorData = `<p>This is a CKEditor 4 instance created with Angular.</p>`;
 }

--- a/scripts/integrations/angular/tsconfig.json
+++ b/scripts/integrations/angular/tsconfig.json
@@ -10,6 +10,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "target": "es5",
+    "skipLibCheck": true,
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
Docs update for https://github.com/ckeditor/ckeditor4-angular/issues/130.

Should be merged when https://github.com/ckeditor/ckeditor4-angular/issues/133 will be released.

Also closes https://github.com/ckeditor/ckeditor4/issues/4125 and partially https://github.com/ckeditor/ckeditor4/issues/3821.