### PR TITLE
Update Mathtype version in docs sample

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1926,9 +1926,9 @@
       }
     },
     "@wiris/mathtype-ckeditor4": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/@wiris/mathtype-ckeditor4/-/mathtype-ckeditor4-7.22.0.tgz",
-      "integrity": "sha512-7jwcbqNHbJAV+xHc54+1PcEXvjgTO2x5qujUTCqRQSJP3kPgKE2Fnim7eihcbhbjVwbG0hqz3c7ABMnhJbNhzQ=="
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@wiris/mathtype-ckeditor4/-/mathtype-ckeditor4-7.24.4.tgz",
+      "integrity": "sha512-W6xunmX/UXBzLxG+V4QrFe4e5gmDFijchar+NBbJWEuimQW8bzQ/qJ/crA77iq+yXefaQ9HXVCSRggUZMR6mgQ=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "@ngtools/webpack": "^7.2.3",
-    "@wiris/mathtype-ckeditor4": "^7.16.0",
+    "@wiris/mathtype-ckeditor4": "^7.24.1",
     "babel-loader": "^8.0.4",
     "chalk": "^2.4.1",
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
According to https://github.com/ckeditor/ckeditor4/issues/4312 & https://github.com/ckeditor/ckeditor4/issues/4280

Bump version of `@wiris/mathtype-ckeditor4` to `^7.24.1`