### PR TITLE
Add info about Spell Checker Dialog End-of-Life

### DIFF
--- a/docs/features/spellcheck/README.md
+++ b/docs/features/spellcheck/README.md
@@ -42,6 +42,10 @@ It is provided by [WebSpellChecker](https://webspellchecker.com/wsc-scayt-ckedit
 
 ## Spell Checking in a Dialog Window
 
+<info-box info="">
+	**This feature has an End-of-Life date set at December 31st, 2021.** We strongly encourage to choose one of the other available solutions - {@link features/spellcheck/README#spell-check-as-you-type-scayt Spell Check As You Type (SCAYT)} or {@link features/spellcheck/README#distraction-free-proofreading WProofreader}.
+</info-box>
+
 The [WebSpellChecker Dialog](https://ckeditor.com/cke4/addon/wsc) plugin is another spell checker solution provided by [WebSpellChecker](https://webspellchecker.com/wsc-dialog-ckeditor4/). It runs the check through a dialog window instead of marking misspelled words inline. Additionally, for some languages a Grammar Checker and Thesaurus feature is also available.
 
 {@img assets/img/wsc_01.png 881 Spell Checker in the dialog window in CKEditor 4 WYSIWYG editor}

--- a/docs/features/spellcheck/README.md
+++ b/docs/features/spellcheck/README.md
@@ -42,8 +42,8 @@ It is provided by [WebSpellChecker](https://webspellchecker.com/wsc-scayt-ckedit
 
 ## Spell Checking in a Dialog Window
 
-<info-box info="">
-	**This feature has an End-of-Life date set at December 31st, 2021.** We strongly encourage to choose one of the other available solutions - {@link features/spellcheck/README#spell-check-as-you-type-scayt Spell Check As You Type (SCAYT)} or {@link features/spellcheck/README#distraction-free-proofreading WProofreader}.
+<info-box warning="">
+	**This feature has an End-of-Life date set at December 31st, 2021.** This means it won't be supported and may stop working after this date. We strongly encourage to choose one of other spellchecking available solutions - {@link features/spellcheck/README#spell-check-as-you-type-scayt Spell Check As You Type (SCAYT)} or {@link features/spellcheck/README#distraction-free-proofreading WProofreader}.
 </info-box>
 
 The [WebSpellChecker Dialog](https://ckeditor.com/cke4/addon/wsc) plugin is another spell checker solution provided by [WebSpellChecker](https://webspellchecker.com/wsc-dialog-ckeditor4/). It runs the check through a dialog window instead of marking misspelled words inline. Additionally, for some languages a Grammar Checker and Thesaurus feature is also available.

--- a/docs/features/spellcheck/README.md
+++ b/docs/features/spellcheck/README.md
@@ -43,7 +43,7 @@ It is provided by [WebSpellChecker](https://webspellchecker.com/wsc-scayt-ckedit
 ## Spell Checking in a Dialog Window
 
 <info-box warning="">
-	**This feature has an End-of-Life date set at December 31st, 2021.** This means it won't be supported and may stop working after this date. We strongly encourage to choose one of other spellchecking available solutions - {@link features/spellcheck/README#spell-check-as-you-type-scayt Spell Check As You Type (SCAYT)} or {@link features/spellcheck/README#distraction-free-proofreading WProofreader}.
+	**This feature has an End-of-Life date set to December 31st, 2021.** This means it will not be supported any longer and may stop working after this date. We strongly encourage everyone to choose one of the other available spellchecking solutions - {@link features/spellcheck/README#spell-check-as-you-type-scayt Spell Check As You Type (SCAYT)} or {@link features/spellcheck/README#distraction-free-proofreading WProofreader}.
 </info-box>
 
 The [WebSpellChecker Dialog](https://ckeditor.com/cke4/addon/wsc) plugin is another spell checker solution provided by [WebSpellChecker](https://webspellchecker.com/wsc-dialog-ckeditor4/). It runs the check through a dialog window instead of marking misspelled words inline. Additionally, for some languages a Grammar Checker and Thesaurus feature is also available.

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -71,7 +71,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<h2>Spell Checking in a Dialog Window</h2>
 
 			<div class="tip tip__warning">
-				<b>This feature has an End-of-Life date set at December 31st, 2021.</b> This means it won't be supported and may stop working after this date. We strongly encourage to choose one of other spellchecking available solutions - <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#spell-check-as-you-type-scayt">Spell Check As You Type (SCAYT)</a> or <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#distraction-free-proofreading">WProofreader</a>.
+				<b>This feature has an End-of-Life date set to December 31st, 2021.</b> This means it will not be supported any longer and may stop working after this date. We strongly encourage everyone to choose one of the other available spellchecking solutions - <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#spell-check-as-you-type-scayt">Spell Check As You Type (SCAYT)</a> or <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#distraction-free-proofreading">WProofreader</a>.
 			</div>
 
 			<p>

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -70,8 +70,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<h2>Spell Checking in a Dialog Window</h2>
 
-			<div class="tip">
-				<b>This feature has an End-of-Life date set at December 31st, 2021.</b> We strongly encourage to choose one of the other available solutions - <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#spell-check-as-you-type-scayt">Spell Check As You Type (SCAYT)</a> or <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#distraction-free-proofreading">WProofreader</a>.
+			<div class="tip tip__warning">
+				<b>This feature has an End-of-Life date set at December 31st, 2021.</b> This means it won't be supported and may stop working after this date. We strongly encourage to choose one of other spellchecking available solutions - <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#spell-check-as-you-type-scayt">Spell Check As You Type (SCAYT)</a> or <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#distraction-free-proofreading">WProofreader</a>.
 			</div>
 
 			<p>

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -70,6 +70,10 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<h2>Spell Checking in a Dialog Window</h2>
 
+			<div class="tip">
+				<b>This feature has an End-of-Life date set at December 31st, 2021.</b> We strongly encourage to choose one of the other available solutions - <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#spell-check-as-you-type-scayt">Spell Check As You Type (SCAYT)</a> or <a href="https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#distraction-free-proofreading">WProofreader</a>.
+			</div>
+
 			<p>
 				The <a href="https://ckeditor.com/cke4/addon/wsc">WebSpellChecker</a> plugin provides the <strong>Spell Checker</strong> dialog window that lets you check the spelling of the document word by word. Additionally, for some languages a Grammar Checker and Thesaurus feature is also available.
 			</p>


### PR DESCRIPTION
I was wondering if the notes shouldn't be warnings instead of notes (like [here](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_spreadsheets.html#updating-data-in-an-existing-spreadsheet-widget)), but we don't use them in examples at all and don't have styles defined for it, so I went with bold instead.

Closes https://github.com/ckeditor/ckeditor4/issues/4423.