### PR TITLE
Add error definition (invalid-callback)

### DIFF
--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -121,6 +121,13 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Additional data:
 	* `responseText`: Upload response text.
 
+## invalid-callback
+
+* Location: `core/creators/themedui.js`
+* Description: Passed callback is not a function.
+* Additional data:
+	* `callback`
+
 ## invalid-license-key
 
 * Location: Various plugins
@@ -180,10 +187,3 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Location: `plugins/uploadimage/plugin.js`
 * Description: An upload URL for the Upload Image feature was not defined. Refer to the {@link guide/dev/integration/file_browse_upload/file_upload/README Uploading Dropped or Pasted Files} article for more information.
 * Additional data: None.
-
-## invalid-callback
-
-* Location: `core/creators/themedui.js`
-* Description: Passed callback is not a function.
-* Additional data:
-	* `callback`

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -185,4 +185,5 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 
 * Location: `core/creators/themedui.js`
 * Description: Passed callback is not a function.
-* Additional data: None.
+* Additional data:
+	* `callback`

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -180,3 +180,9 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Location: `plugins/uploadimage/plugin.js`
 * Description: An upload URL for the Upload Image feature was not defined. Refer to the {@link guide/dev/integration/file_browse_upload/file_upload/README Uploading Dropped or Pasted Files} article for more information.
 * Additional data: None.
+
+## invalid-callback
+
+* Location: `core/creators/themedui.js`
+* Description: Passed callback is not a function.
+* Additional data: None.


### PR DESCRIPTION
According to ckeditor/ckeditor4#4461:

Added `invalid-callback` error documentation.  
It could be thrown whenever a callback function is expected, but something else was provided.