### PR TITLE
Add docs about handling widgets with keyboard shortcuts

### DIFF
--- a/docs/features/shortcuts/README.md
+++ b/docs/features/shortcuts/README.md
@@ -80,6 +80,13 @@ The list below contains available keyboard shortcuts grouped by problem areas. Y
 * <kbd>Shift+PgUp</kbd> &ndash; Selects a text fragment of approximately the length of the editing area starting from the cursor
 	and going up.
 
+### On widget selection
+
+* <kbd>Enter</kbd> &ndash; Opens widget dialog.
+* <kbd>Shift+Enter</kbd> &ndash; Adds an empty paragraph after selected widget.
+* <kbd>Shift+Alt+Enter</kbd> &ndash; Adds an empty paragraph before selected widget.
+* <kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> &ndash; Moves selection before or after widget.
+
 ## Text Styling
 
 * <kbd>Ctrl+B</kbd> &ndash; Applies **bold** formatting to a text fragment.

--- a/docs/features/shortcuts/README.md
+++ b/docs/features/shortcuts/README.md
@@ -82,10 +82,10 @@ The list below contains available keyboard shortcuts grouped by problem areas. Y
 
 ### Widget Selection
 
-* <kbd>Enter</kbd> &ndash; Opens widget dialog.
-* <kbd>Shift+Enter</kbd> &ndash; Adds an empty paragraph after selected widget.
-* <kbd>Shift+Alt+Enter</kbd> &ndash; Adds an empty paragraph before selected widget.
-* <kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> &ndash; Moves selection before or after widget.
+* <kbd>Enter</kbd> &ndash; Opens a widget dialog.
+* <kbd>Shift+Enter</kbd> &ndash; Adds an empty paragraph after the selected widget.
+* <kbd>Shift+Alt+Enter</kbd> &ndash; Adds an empty paragraph before the selected widget.
+* <kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> &ndash; Moves selection before or after the widget.
 
 ## Text Styling
 

--- a/docs/features/shortcuts/README.md
+++ b/docs/features/shortcuts/README.md
@@ -80,7 +80,7 @@ The list below contains available keyboard shortcuts grouped by problem areas. Y
 * <kbd>Shift+PgUp</kbd> &ndash; Selects a text fragment of approximately the length of the editing area starting from the cursor
 	and going up.
 
-### On widget selection
+### Widget selection
 
 * <kbd>Enter</kbd> &ndash; Opens widget dialog.
 * <kbd>Shift+Enter</kbd> &ndash; Adds an empty paragraph after selected widget.

--- a/docs/features/shortcuts/README.md
+++ b/docs/features/shortcuts/README.md
@@ -80,7 +80,7 @@ The list below contains available keyboard shortcuts grouped by problem areas. Y
 * <kbd>Shift+PgUp</kbd> &ndash; Selects a text fragment of approximately the length of the editing area starting from the cursor
 	and going up.
 
-### Widget selection
+### Widget Selection
 
 * <kbd>Enter</kbd> &ndash; Opens widget dialog.
 * <kbd>Shift+Enter</kbd> &ndash; Adds an empty paragraph after selected widget.

--- a/docs/guide/dev/deep_dive/widgets/README.md
+++ b/docs/guide/dev/deep_dive/widgets/README.md
@@ -59,9 +59,8 @@ Technically, **each widget is defined in a CKEditor plugin that uses the feature
 
 ## Accessibility
 
-When a widget is selected, keyboard shortcuts are adjusted to make navigation and edition around widget comfortable. For example, widget dialog window can be opened by just pressing <kbd>Enter</kbd> key. All shortcuts are described in {@link features/shortcuts/README#widget-selection Keyboard Shortcuts article}.
+When a widget is selected, keyboard shortcuts are adjusted to make the navigation and edition around the widget more comfortable. For example, a widget dialog window can be opened by just pressing the <kbd>Enter</kbd> key. All shortcuts are described in the {@link features/shortcuts/README#widget-selection Keyboard Shortcuts} guide.
 
 ## Further Reading
 
 If you want to create your own widgets, take a look at the {@link guide/widget_sdk/intro/README Widget SDK} that includes a {@link guide/widget_sdk/tutorial_1/README step-by-step tutorial} on how to create widgets.
-

--- a/docs/guide/dev/deep_dive/widgets/README.md
+++ b/docs/guide/dev/deep_dive/widgets/README.md
@@ -57,6 +57,10 @@ The screenshot above shows a customized CKEditor 4 instance that uses a few samp
 
 Technically, **each widget is defined in a CKEditor plugin that uses the features provided by the generic [Widget plugin](https://ckeditor.com/cke4/addon/widget)**. Owing to this, widget plugins have a structure very similar to that of standard editor plugins, can be made available in [CKEditor 4 Add-ons Repository](https://ckeditor.com/cke4/addons/plugins/all), and can be added to your editor installation as described in the {@link guide/dev/widget_installation/README Widget Installation} article.
 
+## Accessibility
+
+When a widget is selected, keyboard shortcuts are adjusted to make navigation and edition around widget comfortable. For example, widget dialog window can be opened by just pressing <kbd>Enter</kbd> key. All shortcuts are described in {@link features/shortcuts/README#widget-selection Keyboard Shortcuts article}.
+
 ## Further Reading
 
 If you want to create your own widgets, take a look at the {@link guide/widget_sdk/intro/README Widget SDK} that includes a {@link guide/widget_sdk/tutorial_1/README step-by-step tutorial} on how to create widgets.


### PR DESCRIPTION
Besides adding info which I've already done, I'd like to propose changing the style of mutlikey shortcuts used on the page; currently all keys that should be pressed are grouped [like this](https://ckeditor.com/docs/ckeditor4/latest/features/shortcuts.html):

`Shift+Enter`

While in corresponding [CKE5 docs](https://ckeditor.com/docs/ckeditor5/latest/features/keyboard-support.html#content-editing) each key is separated:

`Shift` + `Enter`

which looks better and more readable for me. However since this article is quite old, I wasn't sure if we want to introduce such a change as some users may already be used to the current notation. Therefore I'm leaving the decision up to reviewer.

Also for the coherence reasons I didn't use arrow symbols `←`, but full words (`Left Arrow`).

Closes https://github.com/ckeditor/ckeditor4/issues/4559.