### PR TITLE
Add docs about 'namespaceLoaded' event in Angular integration guide

### DIFF
--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -197,6 +197,30 @@ This property takes precedence over the {@linkapi CKEDITOR.config#readOnly `conf
 
 The following `@Output` properties are supported by the CKEditor 4 Angular component:
 
+### `namespaceLoaded`
+
+Fired when the {@linkapi CKEDITOR `CKEDITOR` namespace} is loaded. It only triggers once, no matter how many CKEditor 4 components are initialised. Can be used for convenient changes in the namespace, e.g. for adding external plugins:
+
+```html
+<ckeditor (namespaceLoaded)="onNamespaceLoaded($event)"></ckeditor>
+```
+
+```typescript
+import { CKEditor4 } from 'ckeditor4-angular/ckeditor';
+
+@Component( {
+	...
+} )
+export class MyComponent {
+	public onNamespaceLoaded( event: CKEditor4.EventInfo ) {
+		// Add external `placeholder` plugin which will be available for each
+		// editor instance on the page.
+		CKEDITOR.plugins.addExternal( 'placeholder', '/path/to/the/placeholder/plugin', 'plugin.js' );
+	}
+	...
+}
+```
+
 ### `ready`
 
 Fires when the editor is ready. It corresponds with the {@linkapi CKEDITOR.editor#instanceReady `editor#instanceReady`} event.
@@ -215,8 +239,7 @@ Please note that this event will only be fired when the [Undo](https://ckeditor.
 <ckeditor (change)="onChange($event)"></ckeditor>
 ```
 
-``` typescript
-
+```typescript
 import { CKEditor4 } from 'ckeditor4-angular/ckeditor';
 
 @Component( {

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -199,7 +199,7 @@ The following `@Output` properties are supported by the CKEditor 4 Angular compo
 
 ### `namespaceLoaded`
 
-Fires when the {@linkapi CKEDITOR `CKEDITOR` namespace} is loaded. It only triggers once, no matter how many CKEditor 4 components are initialised. Can be used for convenient changes in the namespace, e.g. for adding external plugins:
+Fires when the {@linkapi CKEDITOR `CKEDITOR` namespace} is loaded. It only triggers once, no matter how many CKEditor 4 components are initialized. Can be used for convenient changes in the namespace, e.g. for adding external plugins:
 
 ```html
 <ckeditor (namespaceLoaded)="onNamespaceLoaded($event)"></ckeditor>

--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -199,7 +199,7 @@ The following `@Output` properties are supported by the CKEditor 4 Angular compo
 
 ### `namespaceLoaded`
 
-Fired when the {@linkapi CKEDITOR `CKEDITOR` namespace} is loaded. It only triggers once, no matter how many CKEditor 4 components are initialised. Can be used for convenient changes in the namespace, e.g. for adding external plugins:
+Fires when the {@linkapi CKEDITOR `CKEDITOR` namespace} is loaded. It only triggers once, no matter how many CKEditor 4 components are initialised. Can be used for convenient changes in the namespace, e.g. for adding external plugins:
 
 ```html
 <ckeditor (namespaceLoaded)="onNamespaceLoaded($event)"></ckeditor>


### PR DESCRIPTION
We don't have such a convention but I was wondering about adding a `since 2.2.0` tag to this event docs (and perhaps for all other `input` and `output` properties). Abstained for now, but if reviewer finds it useful I can add it too.

It should be merged after the release of `2.2.0` Angular integration version.

Closes https://github.com/ckeditor/ckeditor4-angular/issues/180.