### PR TITLE
Add delayed editor creation error codes info

### DIFF
--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -58,7 +58,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Additional data:
 	* `method`: Indicates how the editor creation proceeded after it was reattached to DOM. Can have one of two values:
 		* `callback` - Editor was created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
-		* `interval - X ms` - Editor tried to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own and eventually succeeded.
+		* `interval - X ms` - The editor tried to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own and eventually succeeded.
 
 ## editor-destroy-iframe
 

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -42,6 +42,24 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Description: The {@linkapi CKEDITOR.config.cloudServices_uploadUrl} configuration variable for the [CKEditor Cloud Services](https://ckeditor.com/cke4/addon/cloudservices) plugin was not specified.
 * Additional data: None.
 
+## editor-delayed-creation
+
+* Location: `core/editor.js`
+* Description: Editor creation {@linkapi CKEDITOR.config.delayIfDetached has been delayed} because its target native element was detached from DOM.
+* Additional data:
+	* `method`: Indicates how to resume editor creation. Can have one of two values:
+		* `callback` - Editor can be created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
+		* `interval - X ms` - Editor will try to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own until its native element is reattached to DOM.
+
+## editor-delayed-creation-success
+
+* Location: `core/editor.js`
+* Description: Editor with {@linkapi CKEDITOR.config.delayIfDetached delayed creation process} was correctly instantiated.
+* Additional data:
+	* `method`: Indicates how the editor creation proceeded after it was reattached to DOM. Can have one of two values:
+		* `callback` - Editor was created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
+		* `interval - X ms` - Editor tried to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own and eventually succeeded.
+
 ## editor-destroy-iframe
 
 * Location: `plugins/wysiwygarea/plugin.js`

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -47,7 +47,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Location: `core/editor.js`
 * Description: The editor creation {@linkapi CKEDITOR.config.delayIfDetached has been delayed} because its target native element was detached from DOM.
 * Additional data:
-	* `method`: Indicates how to resume editor creation. Can have one of two values:
+	* `method`: Indicates how to resume editor creation. It can have one of these two values:
 		* `callback` - Editor can be created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
 		* `interval - X ms` - Editor will try to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own until its native element is reattached to DOM.
 

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -54,7 +54,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 ## editor-delayed-creation-success
 
 * Location: `core/editor.js`
-* Description: Editor with {@linkapi CKEDITOR.config.delayIfDetached delayed creation process} was correctly instantiated.
+* Description: The editor with a {@linkapi CKEDITOR.config.delayIfDetached delayed creation process} was correctly instantiated.
 * Additional data:
 	* `method`: Indicates how the editor creation proceeded after it was reattached to DOM. Can have one of two values:
 		* `callback` - Editor was created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -56,7 +56,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Location: `core/editor.js`
 * Description: The editor with a {@linkapi CKEDITOR.config.delayIfDetached delayed creation process} was correctly instantiated.
 * Additional data:
-	* `method`: Indicates how the editor creation proceeded after it was reattached to DOM. Can have one of two values:
+	* `method`: Indicates how the editor creation proceeded after it was reattached to DOM. It can have one of these two values:
 		* `callback` - Editor was created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
 		* `interval - X ms` - The editor tried to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own and eventually succeeded.
 

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -49,7 +49,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Additional data:
 	* `method`: Indicates how to resume editor creation. It can have one of these two values:
 		* `callback` - Editor can be created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
-		* `interval - X ms` - Editor will try to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own until its native element is reattached to DOM.
+		* `interval - X ms` - The editor will try to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own until its native element is reattached to DOM.
 
 ## editor-delayed-creation-success
 

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -57,7 +57,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Description: The editor with a {@linkapi CKEDITOR.config.delayIfDetached delayed creation process} was correctly instantiated.
 * Additional data:
 	* `method`: Indicates how the editor creation proceeded after it was reattached to DOM. It can have one of these two values:
-		* `callback` - Editor was created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
+		* `callback` - The editor was created with a callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
 		* `interval - X ms` - The editor tried to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own and eventually succeeded.
 
 ## editor-destroy-iframe

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -48,7 +48,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Description: The editor creation {@linkapi CKEDITOR.config.delayIfDetached has been delayed} because its target native element was detached from DOM.
 * Additional data:
 	* `method`: Indicates how to resume editor creation. It can have one of these two values:
-		* `callback` - Editor can be created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
+		* `callback` - The editor can be created with a callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.
 		* `interval - X ms` - The editor will try to instantiate {@linkapi CKEDITOR.config.delayIfDetached_interval every `X ms`} on its own until its native element is reattached to DOM.
 
 ## editor-delayed-creation-success

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -45,7 +45,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 ## editor-delayed-creation
 
 * Location: `core/editor.js`
-* Description: Editor creation {@linkapi CKEDITOR.config.delayIfDetached has been delayed} because its target native element was detached from DOM.
+* Description: The editor creation {@linkapi CKEDITOR.config.delayIfDetached has been delayed} because its target native element was detached from DOM.
 * Additional data:
 	* `method`: Indicates how to resume editor creation. Can have one of two values:
 		* `callback` - Editor can be created with callback function provided through {@linkapi CKEDITOR.config.delayIfDetached_callback} configuration variable.


### PR DESCRIPTION
PR adds docs for two new error codes introduced in https://github.com/ckeditor/ckeditor4/pull/4463:
- `editor-delayed-creation`
- `editor-delayed-creation-success`

Closes https://github.com/ckeditor/ckeditor4/issues/4564.