### PR TITLE
Ignore errors reported by the crawler

### DIFF
--- a/docs/sdk/examples/easyimage.html
+++ b/docs/sdk/examples/easyimage.html
@@ -11,6 +11,9 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<meta name="sdk-samples" content="Easy Image Plugin">
 	<meta name="sdk-category" content="sdk-inserting-images">
 	<meta name="sdk-order" content="30">
+	<meta name="x-cke-crawler-ignore-patterns" content='{
+		"request-failure": "33333.cdn.cke-cs.com"
+	}'>
 	<title>Easy Image Plugin</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">

--- a/docs/sdk/examples/spreadsheets.html
+++ b/docs/sdk/examples/spreadsheets.html
@@ -14,6 +14,10 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Spreadsheets</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<meta name="x-cke-crawler-ignore-patterns" content='{
+		"uncaught-exception": "Cannot read property",
+		"console-error": "[CKEDITOR]"
+	}'>
 	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>


### PR DESCRIPTION
A few months ago, we created in CKEditor 5 [a tool for verifying whether our documentation and manual tests do not throw errors](https://github.com/ckeditor/ckeditor5-dev/blob/66a8fe44fc1f35fff5736507e2f1c28e6f677299/packages/ckeditor5-dev-docs/lib/web-crawler/index.js). We have been using it for a few months, and it works as expected. Recently we added the verification steps on CI, and also, we are happy about that.

The next step is to replace a validator in the documentation builder that sometimes does not work.

All job is almost done. Now I'm fixing issues that the tool reported.

![image](https://user-images.githubusercontent.com/2270764/118790101-bf0efb00-b895-11eb-9459-2ce807803a45.png)

Some of them occur because the software licenses are assigned to the `ckeditor.com` domain instead of `fake.ckeditor.com` that we use for validating.

In such cases, we'd like to ignore these errors. And this PR introduces the change.
