### PR TITLE
Added a license key to the Spellchecker and Language demos

### DIFF
--- a/docs/sdk/examples/language.html
+++ b/docs/sdk/examples/language.html
@@ -111,7 +111,9 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					extraPlugins: 'bidi',
 					// Setting default language direction to right-to-left.
 					contentsLangDirection: 'rtl',
-					height: 270
+					height: 270,
+					scayt_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
+					scayt_sLang: 'auto'
 				} );
 			</script>
 
@@ -120,7 +122,9 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					extraPlugins: 'language',
 					// Customizing list of languages available in the Language drop-down.
 					language_list: [ 'ar:Arabic:rtl', 'fr:French',  'he:Hebrew:rtl', 'es:Spanish' ],
-					height: 270
+					height: 270,
+					scayt_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
+					scayt_sLang: 'auto'
 				} );
 			</script>
 

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -134,7 +134,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					scayt_autoStartup: true,
 					// Limit the number of suggestions available in the context menu.
 					scayt_maxSuggestions: 3,
-					scayt_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd'
+					scayt_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
+					scayt_sLang: 'en_US'
 				} );
 			</script>
 
@@ -144,8 +145,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Remove the SpellCheckAsYouType (SCAYT) plugin.
 					removePlugins: 'scayt',
 					// Add the WebSpellChecker plugin.
-					extraPlugins: 'wsc',
-					wsc_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd'
+					extraPlugins: 'wsc'
 				} );
 			</script>
 

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -133,7 +133,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Configure SCAYT to load on editor startup.
 					scayt_autoStartup: true,
 					// Limit the number of suggestions available in the context menu.
-					scayt_maxSuggestions: 3
+					scayt_maxSuggestions: 3,
+					scayt_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd'
 				} );
 			</script>
 
@@ -143,7 +144,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Remove the SpellCheckAsYouType (SCAYT) plugin.
 					removePlugins: 'scayt',
 					// Add the WebSpellChecker plugin.
-					extraPlugins: 'wsc'
+					extraPlugins: 'wsc',
+					wsc_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd'
 				} );
 			</script>
 
@@ -152,7 +154,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					autoSearch: true,
 					enableAutoSearchIn: [ '.cke_wproofreader' ],
 					enableGrammar: true,
-					serviceId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd'
+					serviceId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
+					lang: 'auto'
 				};
 
 				CKEDITOR.replace( 'editor3', {


### PR DESCRIPTION
This PR adds a license key to the spellchecker in the following demos:

*   [https://ckeditor.com/docs/ckeditor4/latest/examples/spellchecker.html,](https://ckeditor.com/docs/ckeditor4/latest/examples/spellchecker.html,)
*   https://ckeditor.com/docs/ckeditor4/latest/examples/language.html