### PR TITLE
Moved the crawler meta-data from meta tag to the script tag

### DIFF
--- a/docs/sdk/examples/easyimage.html
+++ b/docs/sdk/examples/easyimage.html
@@ -11,9 +11,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<meta name="sdk-samples" content="Easy Image Plugin">
 	<meta name="sdk-category" content="sdk-inserting-images">
 	<meta name="sdk-order" content="30">
-	<meta name="x-cke-crawler-ignore-patterns" content='{
-		"request-failure": "33333.cdn.cke-cs.com"
-	}'>
 	<title>Easy Image Plugin</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
@@ -287,6 +284,17 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</script>
 
 			<script>
+				// Umberto SDK does not copy the `<head>` content, so the crawler option will not be visible in the output file.
+				// That's why it is added manually in the `<script>` tag.
+				const metaElement = document.createElement( 'meta' );
+
+				metaElement.name = 'x-cke-crawler-ignore-patterns';
+				metaElement.content = JSON.stringify( {
+					'request-failure': '33333.cdn.cke-cs.com'
+				} );
+
+				document.head.appendChild( metaElement );
+
 				CKEDITOR.once( 'instanceReady', function( evt ) {
 					setupOptimizationsCalculator( evt.editor, '#optimizations' );
 				} );

--- a/docs/sdk/examples/spreadsheets.html
+++ b/docs/sdk/examples/spreadsheets.html
@@ -14,10 +14,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<title>Spreadsheets</title>
 	<link href="https://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
 	<link href="../template/theme/css/sdk.css" rel="stylesheet">
-	<meta name="x-cke-crawler-ignore-patterns" content='{
-		"uncaught-exception": "Cannot read property",
-		"console-error": "[CKEDITOR]"
-	}'>
 	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -521,6 +517,18 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</ul>
 
 		<script>
+			// Umberto SDK does not copy the `<head>` content, so the crawler option will not be visible in the output file.
+			// That's why it is added manually in the `<script>` tag.
+			const metaElement = document.createElement( 'meta' );
+
+			metaElement.name = 'x-cke-crawler-ignore-patterns';
+			metaElement.content = JSON.stringify( {
+				'uncaught-exception': 'Cannot read property',
+				'console-error': '[CKEDITOR]'
+			} );
+
+			document.head.appendChild( metaElement );
+
 			var LICENSE_KEY = 'JcbYHjXk45Gx8z/KGByD5NYamnLx/qb8BofSqNLTrbzolE02wKBaYkNApb7x3011Ll75lFLiCqizhBY7NyAaDzh8DEyy1wEPFMja4b3U3vAAyE3InbDUpOeXYmcK9wcRj9Ank3AGGJQVawLEtsg9dUu0VHk8bYl5KN8VUwQUB0ltX5QwQKv/esNKbF1nQg9P3x43qdB6M1PSTtsb1aN4h9FB';
 
 			CKEDITOR.addCss( '.cke table, th, td {border-collapse: collapse;border: 1px solid #444;} .cke table {width: 100%;} .cke th, td {padding: 0 2px;}' );


### PR DESCRIPTION
For an unknown reason, Umberto does not copy the `<meta name="x-cke-crawler-ignore-patterns"> element in the output page, so the element will be created manually in the `<script>` tag to avoid troubles and complications.