### PR TITLE
Fix misleading Angular sample showing `divarea` editor creation

### DIFF
--- a/docs/guide/dev/integration/angular/README.md
+++ b/docs/guide/dev/integration/angular/README.md
@@ -86,7 +86,6 @@ To use the `divarea` editor in `2.0.0` and later versions, you just need to incl
 ```html
 <ckeditor
 	data="<p>Some initial data</p>"
-	type="inline"
 	[config]="{ extraPlugins: 'divarea' }"
 ></ckeditor>
 ```


### PR DESCRIPTION
As pointed out in https://github.com/ckeditor/ckeditor4-angular/issues/198 user doesn't need to change the editor type to `inline` - adding `divarea` plugin is enough to have a `divarea` type editor.