### PR TITLE
Added notification after paste content from external sources (Word, Excel etc.) to the examples 

### DIFF
--- a/docs/sdk/examples/abbr.html
+++ b/docs/sdk/examples/abbr.html
@@ -78,9 +78,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'abbr', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/abbr/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
-					extraPlugins: 'abbr'
+					extraPlugins: 'abbr',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/abbr.html
+++ b/docs/sdk/examples/abbr.html
@@ -74,6 +74,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./api.html">API Usage &ndash; Using CKEditor 4 API</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.plugins.addExternal( 'abbr', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/abbr/', 'plugin.js' );
 
@@ -82,8 +83,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 		</section>
 	</section>
 

--- a/docs/sdk/examples/abbr.html
+++ b/docs/sdk/examples/abbr.html
@@ -82,7 +82,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/accessibility.html
+++ b/docs/sdk/examples/accessibility.html
@@ -118,14 +118,13 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./language.html">Styling and Formatting &ndash; Creating Multilingual Content</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 500,
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 		</section>
 	</section>
 

--- a/docs/sdk/examples/accessibility.html
+++ b/docs/sdk/examples/accessibility.html
@@ -124,7 +124,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/accessibility.html
+++ b/docs/sdk/examples/accessibility.html
@@ -120,9 +120,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					height: 500
+					height: 500,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/accessibilitychecker.html
+++ b/docs/sdk/examples/accessibilitychecker.html
@@ -141,6 +141,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./tabindex.html">Accessibility Support &ndash; Page Navigation Using the "Tab" Key</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.plugins.addExternal( 'a11ychecker', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/a11ychecker/', 'plugin.js' );
 
@@ -188,8 +189,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					]
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 		</section>
 	</section>
 

--- a/docs/sdk/examples/accessibilitychecker.html
+++ b/docs/sdk/examples/accessibilitychecker.html
@@ -179,7 +179,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 							'pNotUsedAsHeader',
 							'tableDataShouldHaveTh',
 							'imgWithEmptyAlt'
-						]
+						],
+						removeButtons: 'PasteFromWord'
 					},
 					contentsCss: [
 						CKEDITOR.basePath + 'contents.css',
@@ -187,6 +188,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					]
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/acf.html
+++ b/docs/sdk/examples/acf.html
@@ -56,6 +56,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<textarea cols="110" rows="3" class="disabled" id="samplehmtl">&lt;p&gt;A sample &lt;u&gt;heavily formatted text&lt;/u&gt; using &lt;strong&gt;&lt;span style="font-family: 'Comic Sans MS';font-size:16px"&gt;different fonts&lt;/span&gt;&lt;/strong&gt; and &lt;span style="font-size:18px;color:#00FF00;background-color: #FFFF00"&gt;text colors&lt;/span&gt;. &lt;/p&gt;</textarea>
 		</div>
 
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 		<script data-sample="1,2,3">
 			// ACF is enabled by default regardless whether toolbar configuration is provided or not.
 			// By having a smaller number of features enabled in the toolbar it should be easier to understand how ACF works.
@@ -127,14 +128,13 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		</p>
 
 		<textarea cols="80" id="editor3" name="editor3" rows="10" data-sample="3">&lt;p&gt;A sample &lt;u&gt;heavily formatted text&lt;/u&gt;, using &lt;strong&gt;&lt;span style="font-family: 'Comic Sans MS';font-size:16px"&gt;different fonts&lt;/span&gt;&lt;/strong&gt; and &lt;span style="font-size:18px;color:#00FF00;background-color: #FFFF00"&gt;text colors&lt;/span&gt;. &lt;/p&gt;</textarea>
+
 		<script data-sample="3">
 			CKEDITOR.replace( 'editor3', {
 				allowedContent: true,
 				removeButtons: 'PasteFromWord'
 			} );
 		</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 		<h2>Related Features</h2>
 
 		<ul>

--- a/docs/sdk/examples/acf.html
+++ b/docs/sdk/examples/acf.html
@@ -90,7 +90,9 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<textarea cols="80" id="editor1" name="editor1" rows="10" data-sample="1">&lt;p&gt;A sample &lt;u&gt;heavily formatted text&lt;/u&gt; using &lt;strong&gt;&lt;span style="font-family: 'Comic Sans MS';font-size:16px"&gt;different fonts&lt;/span&gt;&lt;/strong&gt; and &lt;span style="font-size:18px;color:#00FF00;background-color: #FFFF00"&gt;text colors&lt;/span&gt;. &lt;/p&gt;</textarea>
 		<script data-sample="1">
-			CKEDITOR.replace( 'editor1' );
+			CKEDITOR.replace( 'editor1', {
+				removeButtons: 'PasteFromWord'
+			} );
 		</script>
 
 		<h2>Adjusting Automatic ACF Mode</h2>
@@ -110,7 +112,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<script data-sample="2">
 
 			CKEDITOR.replace( 'editor2', {
-				extraAllowedContent: 'u;span{color}'
+				extraAllowedContent: 'u;span{color}',
+				removeButtons: 'PasteFromWord'
 			} );
 
 		</script>
@@ -126,9 +129,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<textarea cols="80" id="editor3" name="editor3" rows="10" data-sample="3">&lt;p&gt;A sample &lt;u&gt;heavily formatted text&lt;/u&gt;, using &lt;strong&gt;&lt;span style="font-family: 'Comic Sans MS';font-size:16px"&gt;different fonts&lt;/span&gt;&lt;/strong&gt; and &lt;span style="font-size:18px;color:#00FF00;background-color: #FFFF00"&gt;text colors&lt;/span&gt;. &lt;/p&gt;</textarea>
 		<script data-sample="3">
 			CKEDITOR.replace( 'editor3', {
-				allowedContent: true
+				allowedContent: true,
+				removeButtons: 'PasteFromWord'
 			} );
 		</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		<h2>Related Features</h2>
 

--- a/docs/sdk/examples/acfcustom.html
+++ b/docs/sdk/examples/acfcustom.html
@@ -64,7 +64,9 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</script>
 
 			<script data-sample="1">
-				CKEDITOR.replace( 'editor1' );
+				CKEDITOR.replace( 'editor1', {
+					removeButtons: 'PasteFromWord'
+				} );
 			</script>
 
 			<h2>Custom ACF Mode</h2>
@@ -133,6 +135,7 @@ span{!font-family};span{!color};span(!marker);
 			</p>
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
+					removeButtons: 'PasteFromWord',
 					allowedContent:
 							'h1 h2 h3 p blockquote strong em;' +
 							'a[!href];' +
@@ -144,6 +147,7 @@ span{!font-family};span{!color};span(!marker);
 							'del ins'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/acfcustom.html
+++ b/docs/sdk/examples/acfcustom.html
@@ -54,6 +54,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					<tr><td style="background-color:#ffdddd;">with background color</td><td style="background-color:#ffdddd;">for bottom cells</td></tr>
 				</table>
 			</textarea>
+
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1,2">
 				CKEDITOR.config.height = 180;
 				// Auto Grow has nothing to do with ACF.
@@ -147,8 +149,6 @@ span{!font-family};span{!color};span(!marker);
 							'del ins'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 			<h2>Related Features</h2>
 
 			<ul>

--- a/docs/sdk/examples/api.html
+++ b/docs/sdk/examples/api.html
@@ -39,6 +39,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				You are using &lt;a href="https://ckeditor.com/"&gt;CKEditor&lt;/a&gt;.&lt;/p&gt;
 			</textarea>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				// Helper function to display messages below CKEditor 4.
 				function ShowMessage( msg ) {
@@ -169,8 +170,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					ShowMessage( 'The number of changes in <em>' + this.name + '</em>: <b>' + ++changesNum + '</b>.' );
 				});
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 			<p id="eMessage" data-sample="1"></p>
 
 			<div id="eButtons" style="display: none" data-sample="1">

--- a/docs/sdk/examples/api.html
+++ b/docs/sdk/examples/api.html
@@ -151,7 +151,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				// Replace the <textarea id="editor1"> with a CKEditor 4 instance.
 				// A reference to the editor object is returned by CKEDITOR.replace() allowing you to work with editor instances.
 				var editor = CKEDITOR.replace( 'editor1', {
-					height: 150
+					height: 150,
+					removeButtons: 'PasteFromWord'
 				} );
 
 				// Attaching event listeners to CKEditor 4 instances.
@@ -168,6 +169,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					ShowMessage( 'The number of changes in <em>' + this.name + '</em>: <b>' + ++changesNum + '</b>.' );
 				});
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<p id="eMessage" data-sample="1"></p>
 

--- a/docs/sdk/examples/assets/pastefromoffice/contents.css
+++ b/docs/sdk/examples/assets/pastefromoffice/contents.css
@@ -1,0 +1,51 @@
+.main__notification.notice {
+    position: fixed;
+    max-width: 650px;
+    border: 1px solid hsl(0, 0%, 89%);
+    border-left-color: hsl(38.8, 92.3%, 69.4%);
+    border-left-width: 3px;
+    box-shadow: 0 2px 6px hsla(0, 0%, 0%, 0.18);
+    /* override .notice class' margins and paddings */
+    padding: 20px 40px 20px 20px;
+    margin: 0;
+    /* elevate the warning above the editor's toolbars */
+    z-index: 99999999;
+    animation: fadeIn .3s ease-in-out forwards;
+}
+
+.main__notification-body {
+    margin-top: 10px;
+}
+
+.main__notification-body p {
+    margin-bottom: 0.3em;
+}
+
+.main__notification-body p:last-child {
+    margin-bottom: 0;
+}
+
+.main__notification-close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 10px;
+    /* reset default button styling */
+    background: none;
+    border: none;
+    box-shadow: none;
+    line-height: 1;
+    transition: background 150ms ease;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    cursor: pointer;
+}
+
+.main__notification-close:hover {
+    background: hsl(0, 0%, 93%);
+}
+
+.main__notification-close:active:focus {
+    outline: none;
+}

--- a/docs/sdk/examples/assets/pastefromoffice/pastefromoffice.js
+++ b/docs/sdk/examples/assets/pastefromoffice/pastefromoffice.js
@@ -1,0 +1,164 @@
+var sources = [
+    {
+        name: 'Google Docs',
+        link: 'pastefromgoogledocs.html',
+        linkName: 'Paste from Google Docs',
+        regex: /id=(\"|\')?docs\-internal\-guid\-/,
+        isAlreadyShow: false
+    },
+    {
+        name: 'Microsoft Word',
+        link: 'pastefromword.html',
+        linkName: 'Paste from Word',
+        regex: getProperWordRegex(),
+        isAlreadyShow: false
+    },
+    {
+        name: 'Microsoft Excel',
+        link: 'pastefromexcel.html',
+        linkName: 'Paste from Excel',
+        regex: /<meta\s*name=generator\s*content="Microsoft\s*Excel\s*\d+"?\/?/gmi,
+        isAlreadyShow: false
+    },
+    {
+        name: 'LibreOffice',
+        link: 'pastefromlibreoffice.html',
+        linkName: 'Paste from LibreOffice',
+        regex: /<meta\s+name=["']?generator["']?\s+content="LibreOffice\s*\d+"?\/?/gmi,
+        isAlreadyShow: false
+    }
+];
+var instances = getInstances();
+// A state variable that indicates if the clipboard notification has been seen.
+// We use the variable for displaying the notification only once per demo.
+let hasNotificationBeenSeen = false;
+
+instances.forEach( function ( instanceName ) {
+    var editor = CKEDITOR.instances[ instanceName ];
+
+    if ( !editor ){
+        return;
+    }
+
+    editor.on( 'instanceReady', function() {
+        editor.on( 'paste', function( evt ) {
+            var pasteData = CKEDITOR.plugins.pastetools.getClipboardData( evt.data, 'text/html' );
+
+            if( !pasteData ){
+                return;
+            }
+
+            var sourceIndex = getPastedSourceIndex( pasteData );
+            // Show notification only once per pasted source format ( Word, Excel ).
+            if( sourceIndex !== -1 && !hasNotificationBeenSeen && !sources[ sourceIndex ].isAlreadyShow ) {
+                var notice = document.querySelector('.main__notification.notice');
+
+                // Remove notification when user trying to paste content from other source than previous. e.g. Word and Excel.
+                if( notice ){
+                    notice.remove();
+                }
+
+                createClipboardInputNotification( sourceIndex );
+                sources[ sourceIndex ].isAlreadyShow = true;
+            }
+        } );
+    } );
+} );
+
+function getInstances() {
+    return CKEDITOR.tools.object.keys( CKEDITOR.instances );
+};
+
+function getProperWordRegex() {
+    if( CKEDITOR.env.ie ){
+        return /(class="?Mso|style=["'][^"]*?\bmso\-|w:WordDocument|<o:\w+>|<\/font>)/i;
+    }
+
+    return CKEDITOR.env.safari ? /xmlns:o="urn:schemas-microsoft-com/i : /<meta\s*name="?generator"?\s*content="?microsoft\s*word\s*\d+"?\/?>/i;
+};
+
+function getPastedSourceIndex( htmlString ){
+    var sourceIndex = -1;
+
+    sources.forEach( function ( source, index ) {
+        if( source.regex.test( htmlString ) ){
+            sourceIndex = index;
+        }
+    } );
+
+    return sourceIndex;
+};
+
+// During building the docs all extra links from the head tag are removed, so we need to add it dynamically.
+function injectStyle() {
+    var style = document.createElement( 'link' );
+
+    style.type = 'text/css';
+    style.rel = 'stylesheet';
+    style.href = 'assets/pastefromoffice/contents.css';
+
+    document.getElementsByTagName( 'head' )[ 0 ].appendChild( style );
+};
+
+// The notification should contain the links to the demos where user can test rich formatting from.
+function createClipboardInputNotification( index ) {
+    var title = 'Hello!';
+    var message = '<p>We detected that you tried to paste content from <strong>' + sources[ index ].name + '</strong>.</p>' +
+    '<p>Please bear in mind that the editor demo to which you try to paste does not have all the features enabled.' +
+        'Due to that, unsupported formatting is being stripped.</p>' +
+    '<p>Check out the <a href="' + sources[ index ].link + '">' + sources[ index ].linkName + '</a> demos for the best experience.</p>';
+
+    window.createNotification( title, message );
+};
+
+/**
+* Creates a notification and appends it to the `.main__content` element.
+*
+* @param {String} title A title of the notification.
+* @param {String} message A message to display in the notification.
+*
+* @returns {Object} A notification element.
+*/
+window.createNotification = function( title, message ) {
+    var notificationTemplate = '<h3 class="main__notification-title">' + title + '</h3>' +
+        '<div class="main__notification-body">' + message + '</div>';
+
+    var notification = document.createElement( 'div' );
+    var close = document.createElement( 'button' );
+
+    close.classList.add( 'main__notification-close' );
+    close.innerText = '✕';
+    close.setAttribute( 'aria-label', 'Close the notification' );
+
+    notification.classList.add( 'main__notification' );
+    notification.classList.add( 'notice' );
+    notification.innerHTML = notificationTemplate;
+    // ATM we support only top-right position.
+    notification.style.top = '110px';
+    notification.style.right = '10px';
+    notification.appendChild( close );
+
+    var activeNotifications = document.querySelectorAll( '.main__notification' );
+
+    // Translate the position of multiple notifications (just in case).
+    if ( activeNotifications.length > 0 ) {
+        var moveOffset = activeNotifications.length * 10;
+
+        notification.style.top = parseInt( notification.style.top ) + moveOffset + 'px';
+        notification.style.right = parseInt( notification.style.right ) + moveOffset + 'px';
+    }
+
+    // Append notification to the `.main__content` element.
+    var main = document.querySelector( '.main__content' );
+    main.appendChild( notification );
+
+    close.addEventListener( 'click', function() {
+        main.removeChild( notification );
+    } );
+
+    return notification;
+};
+
+window.onload = function () {
+    injectStyle();
+};

--- a/docs/sdk/examples/assets/pastefromoffice/pastefromoffice.js
+++ b/docs/sdk/examples/assets/pastefromoffice/pastefromoffice.js
@@ -39,7 +39,6 @@ CKEDITOR.on( 'instanceReady', function( evt ) {
 
 	editor.on( 'paste', function( evt ) {
 		var pasteData = getClipboardData( evt.data, 'text/html' );
-
 		if( !pasteData ){
 			return;
 		}
@@ -126,12 +125,11 @@ window.createNotification = function( title, message ) {
     var notification = document.createElement( 'div' );
     var close = document.createElement( 'button' );
 
-    close.classList.add( 'main__notification-close' );
+    close.className += 'main__notification-close';
     close.innerText = '✕';
     close.setAttribute( 'aria-label', 'Close the notification' );
 
-    notification.classList.add( 'main__notification' );
-    notification.classList.add( 'notice' );
+    notification.className += 'main__notification notice';
     notification.innerHTML = notificationTemplate;
     // ATM we support only top-right position.
     notification.style.top = '110px';

--- a/docs/sdk/examples/assets/pastefromoffice/pastefromoffice.js
+++ b/docs/sdk/examples/assets/pastefromoffice/pastefromoffice.js
@@ -159,7 +159,7 @@
 		return notification;
 	};
 
-	window.onload = function () {
+	window.onload = function() {
 		injectStyle();
 	};
-} )( );
+} )();

--- a/docs/sdk/examples/assets/pastefromoffice/pastefromoffice.js
+++ b/docs/sdk/examples/assets/pastefromoffice/pastefromoffice.js
@@ -2,161 +2,164 @@
  * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
-
- var sources = [
-    {
-        name: 'Google Docs',
-        link: 'pastefromgoogledocs.html',
-        linkName: 'Paste from Google Docs',
-        regex: /id=(\"|\')?docs\-internal\-guid\-/,
-        isAlreadyShow: false
-    },
-    {
-        name: 'Microsoft Word',
-        link: 'pastefromword.html',
-        linkName: 'Paste from Word',
-        regex: getProperWordRegex(),
-        isAlreadyShow: false
-    },
-    {
-        name: 'Microsoft Excel',
-        link: 'pastefromexcel.html',
-        linkName: 'Paste from Excel',
-        regex: /<meta\s*name=generator\s*content="Microsoft\s*Excel\s*\d+"?\/?/gmi,
-        isAlreadyShow: false
-    },
-    {
-        name: 'LibreOffice',
-        link: 'pastefromlibreoffice.html',
-        linkName: 'Paste from LibreOffice',
-        regex: /<meta\s+name=["']?generator["']?\s+content="LibreOffice\s*\d+"?\/?/gmi,
-        isAlreadyShow: false
-    }
-];
-
-CKEDITOR.on( 'instanceReady', function( evt ) {
-	var editor = evt.editor;
-
-	editor.on( 'paste', function( evt ) {
-		var pasteData = getClipboardData( evt.data, 'text/html' );
-		if( !pasteData ){
-			return;
+( function() {
+	var sources = [
+		{
+			name: 'Google Docs',
+			link: 'pastefromgoogledocs.html',
+			linkName: 'Paste from Google Docs',
+			regex: /id=(\"|\')?docs\-internal\-guid\-/,
+			isAlreadyShow: false
+		},
+		{
+			name: 'Microsoft Word',
+			link: 'pastefromword.html',
+			linkName: 'Paste from Word',
+			regex: getProperWordRegex(),
+			isAlreadyShow: false
+		},
+		{
+			name: 'Microsoft Excel',
+			link: 'pastefromexcel.html',
+			linkName: 'Paste from Excel',
+			regex: /<meta\s*name=generator\s*content="Microsoft\s*Excel\s*\d+"?\/?/gmi,
+			isAlreadyShow: false
+		},
+		{
+			name: 'LibreOffice',
+			link: 'pastefromlibreoffice.html',
+			linkName: 'Paste from LibreOffice',
+			regex: /<meta\s+name=["']?generator["']?\s+content="LibreOffice\s*\d+"?\/?/gmi,
+			isAlreadyShow: false
 		}
+	];
 
-		for ( var i = 0; i < sources.length; i++ ) {
-			var source = sources[ i ];
+	CKEDITOR.on( 'instanceReady', function( evt ) {
+		var editor = evt.editor;
 
-			if( source.regex.test( pasteData ) && !sources[ i ].isAlreadyShow ) {
-				var notice = document.querySelector( '.main__notification.notice' );
-
-				// Remove notification when user trying to paste content from other source than previous. e.g. Word and Excel.
-				if( notice ){
-					notice.remove();
-				}
-
-				createClipboardInputNotification( i );
-				sources[ i ].isAlreadyShow = true;
-				break;
+		editor.on( 'paste', function( evt ) {
+			var pasteData = getClipboardData( evt.data, 'text/html' );
+			if( !pasteData ){
+				return;
 			}
+
+			for ( var i = 0; i < sources.length; i++ ) {
+				var source = sources[ i ];
+
+				if( source.regex.test( pasteData ) && !source.isAlreadyShow ) {
+					var notice = document.querySelector( '.main__notification.notice' );
+
+					// Remove notification when user trying to paste content from other source than previous. e.g. Word and Excel.
+					if( notice ){
+						notice.remove();
+					}
+
+					createClipboardInputNotification( source );
+					sources[ i ].isAlreadyShow = true;
+					break;
+				}
+			}
+		// Some of plugins may cancel execution of this event due to their own custom paste event contained within in the plugin.
+		// To avoid this, the default priority(10) has been changed.
+		}, null, null, 9 );
+	} );
+
+	function getClipboardData( data, type ) {
+		var dataTransfer;
+
+		if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported && type !== 'text/html' ) {
+			return null;
 		}
-	}, null, null, 9 );
-} );
 
-function getClipboardData( data, type ) {
-	var dataTransfer;
+		dataTransfer = data.dataTransfer.getData( type, true );
 
-	if ( !CKEDITOR.plugins.clipboard.isCustomDataTypesSupported && type !== 'text/html' ) {
-		return null;
+		// Some commands fire paste event without setting dataTransfer property. In such case
+		// dataValue should be used for retrieving HTML.
+		if ( !dataTransfer && type === 'text/html' ) {
+			return data.dataValue;
+		}
+
+		return dataTransfer;
 	}
 
-	dataTransfer = data.dataTransfer.getData( type, true );
+	function getProperWordRegex() {
+		if( CKEDITOR.env.ie ){
+			return /(class="?Mso|style=["'][^"]*?\bmso\-|w:WordDocument|<o:\w+>|<\/font>)/i;
+		}
 
-	// Some commands fire paste event without setting dataTransfer property. In such case
-	// dataValue should be used for retrieving HTML.
-	if ( !dataTransfer && type === 'text/html' ) {
-		return data.dataValue;
-	}
+		return CKEDITOR.env.safari ? /xmlns:o="urn:schemas-microsoft-com/i : /<meta\s*name="?generator"?\s*content="?microsoft\s*word\s*\d+"?\/?>/i;
+	};
 
-	return dataTransfer;
-}
+	// During building the docs all extra links from the head tag are removed, so we need to add it dynamically.
+	function injectStyle() {
+		var style = document.createElement( 'link' );
 
-function getProperWordRegex() {
-    if( CKEDITOR.env.ie ){
-        return /(class="?Mso|style=["'][^"]*?\bmso\-|w:WordDocument|<o:\w+>|<\/font>)/i;
-    }
+		style.type = 'text/css';
+		style.rel = 'stylesheet';
+		style.href = 'assets/pastefromoffice/contents.css';
 
-    return CKEDITOR.env.safari ? /xmlns:o="urn:schemas-microsoft-com/i : /<meta\s*name="?generator"?\s*content="?microsoft\s*word\s*\d+"?\/?>/i;
-};
+		document.getElementsByTagName( 'head' )[ 0 ].appendChild( style );
+	};
 
-// During building the docs all extra links from the head tag are removed, so we need to add it dynamically.
-function injectStyle() {
-    var style = document.createElement( 'link' );
+	// The notification should contain the links to the demos where user can test rich formatting from.
+	function createClipboardInputNotification( source ) {
+		var title = 'Hello!';
+		var message = '<p>We detected that you tried to paste content from <strong>' + source.name + '</strong>.</p>' +
+		'<p>Please bear in mind that the editor demo to which you try to paste does not have all the features enabled.' +
+			'Due to that, unsupported formatting is being stripped.</p>' +
+		'<p>Check out the <a href="' + source.link + '">' + source.linkName + '</a> demos for the best experience.</p>';
 
-    style.type = 'text/css';
-    style.rel = 'stylesheet';
-    style.href = 'assets/pastefromoffice/contents.css';
+		window.createNotification( title, message );
+	};
 
-    document.getElementsByTagName( 'head' )[ 0 ].appendChild( style );
-};
+	/**
+	* Creates a notification and appends it to the `.main__content` element.
+	*
+	* @param {String} title A title of the notification.
+	* @param {String} message A message to display in the notification.
+	*
+	* @returns {Object} A notification element.
+	*/
+	window.createNotification = function( title, message ) {
+		var notificationTemplate = '<h3 class="main__notification-title">' + title + '</h3>' +
+			'<div class="main__notification-body">' + message + '</div>';
 
-// The notification should contain the links to the demos where user can test rich formatting from.
-function createClipboardInputNotification( index ) {
-    var title = 'Hello!';
-    var message = '<p>We detected that you tried to paste content from <strong>' + sources[ index ].name + '</strong>.</p>' +
-    '<p>Please bear in mind that the editor demo to which you try to paste does not have all the features enabled.' +
-        'Due to that, unsupported formatting is being stripped.</p>' +
-    '<p>Check out the <a href="' + sources[ index ].link + '">' + sources[ index ].linkName + '</a> demos for the best experience.</p>';
+		var notification = document.createElement( 'div' );
+		var close = document.createElement( 'button' );
 
-    window.createNotification( title, message );
-};
+		close.className += 'main__notification-close';
+		close.innerText = '✕';
+		close.setAttribute( 'aria-label', 'Close the notification' );
 
-/**
-* Creates a notification and appends it to the `.main__content` element.
-*
-* @param {String} title A title of the notification.
-* @param {String} message A message to display in the notification.
-*
-* @returns {Object} A notification element.
-*/
-window.createNotification = function( title, message ) {
-    var notificationTemplate = '<h3 class="main__notification-title">' + title + '</h3>' +
-        '<div class="main__notification-body">' + message + '</div>';
+		notification.className += 'main__notification notice';
+		notification.innerHTML = notificationTemplate;
+		// ATM we support only top-right position.
+		notification.style.top = '110px';
+		notification.style.right = '10px';
+		notification.appendChild( close );
 
-    var notification = document.createElement( 'div' );
-    var close = document.createElement( 'button' );
+		var activeNotifications = document.querySelectorAll( '.main__notification' );
 
-    close.className += 'main__notification-close';
-    close.innerText = '✕';
-    close.setAttribute( 'aria-label', 'Close the notification' );
+		// Translate the position of multiple notifications (just in case).
+		if ( activeNotifications.length > 0 ) {
+			var moveOffset = activeNotifications.length * 10;
 
-    notification.className += 'main__notification notice';
-    notification.innerHTML = notificationTemplate;
-    // ATM we support only top-right position.
-    notification.style.top = '110px';
-    notification.style.right = '10px';
-    notification.appendChild( close );
+			notification.style.top = parseInt( notification.style.top ) + moveOffset + 'px';
+			notification.style.right = parseInt( notification.style.right ) + moveOffset + 'px';
+		}
 
-    var activeNotifications = document.querySelectorAll( '.main__notification' );
+		// Append notification to the `.main__content` element.
+		var main = document.querySelector( '.main__content' );
+		main.appendChild( notification );
 
-    // Translate the position of multiple notifications (just in case).
-    if ( activeNotifications.length > 0 ) {
-        var moveOffset = activeNotifications.length * 10;
+		close.addEventListener( 'click', function() {
+			main.removeChild( notification );
+		} );
 
-        notification.style.top = parseInt( notification.style.top ) + moveOffset + 'px';
-        notification.style.right = parseInt( notification.style.right ) + moveOffset + 'px';
-    }
+		return notification;
+	};
 
-    // Append notification to the `.main__content` element.
-    var main = document.querySelector( '.main__content' );
-    main.appendChild( notification );
-
-    close.addEventListener( 'click', function() {
-        main.removeChild( notification );
-    } );
-
-    return notification;
-};
-
-window.onload = function () {
-    injectStyle();
-};
+	window.onload = function () {
+		injectStyle();
+	};
+} )( );

--- a/docs/sdk/examples/autocomplete.html
+++ b/docs/sdk/examples/autocomplete.html
@@ -164,9 +164,9 @@
 							description: 'Technician which will handle this ticket.'
 						}
 					];
-			
+
 					CKEDITOR.addCss( 'span > .cke_placeholder { background-color: #ffeec2; }' );
-			
+
 					CKEDITOR.replace( 'editor1', {
 						plugins: 'autocomplete,textmatch,toolbar,wysiwygarea,basicstyles,link,undo,placeholder',
 						toolbar: [
@@ -181,67 +181,70 @@
 										'<div><i>{description}</i></div>' +
 									'</li>',
 									outputTemplate = '[[{title}]]<span>&nbsp;</span>';
-		
+
 								var autocomplete = new CKEDITOR.plugins.autocomplete( evt.editor, {
 									textTestCallback: textTestCallback,
 									dataCallback: dataCallback,
 									itemTemplate: itemTemplate,
 									outputTemplate: outputTemplate
 								} );
-		
+
 								// Override default getHtmlToInsert to enable rich content output.
 								autocomplete.getHtmlToInsert = function( item ) {
 									return this.outputTemplate.output( item );
 								}
 							}
-						}
+						},
+						removeButtons: 'PasteFromWord'
 					} );
-		
+
 					function textTestCallback( range ) {
 						if ( !range.collapsed ) {
 							return null;
 						}
-		
+
 						return CKEDITOR.plugins.textMatch.match( range, matchCallback );
 					}
-		
+
 					function matchCallback( text, offset ) {
 						var pattern = /\[{2}([A-z]|\])*$/,
 							match = text.slice( 0, offset )
 							.match( pattern );
-		
+
 						if ( !match ) {
 							return null;
 						}
-		
+
 						return {
 							start: match.index,
 							end: offset
 						};
 					}
-		
+
 					function dataCallback( matchInfo, callback ) {
 						var data = PLACEHOLDERS.filter( function( item ) {
 							var itemName = '[[' + item.name + ']]';
 							return itemName.indexOf( matchInfo.query.toLowerCase() ) == 0;
 						} );
-		
+
 						callback( data );
 					}
 				</script>
-			
+
 				<script>
 					var templates = CKEDITOR.document.findOne( '.templates' ),
 						list = new CKEDITOR.dom.element( 'ul' );
-		
+
 					CKEDITOR.tools.array.forEach( PLACEHOLDERS, function( placeholder ) {
 						var item = new CKEDITOR.dom.element( 'li' );
 						item.setHtml( '<code>' + placeholder.name + '</code>' );
 						list.append( item );
 					} );
-		
+
 					templates.append( list );
 				</script>
+				<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 			</section>
 		</section>
 

--- a/docs/sdk/examples/autocomplete.html
+++ b/docs/sdk/examples/autocomplete.html
@@ -101,6 +101,7 @@
 					<li><a href="./mentions.html">Working with Document &ndash; Mentions, Tags and Emoji</a></li>
 				</ul>
 
+				<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 				<script data-sample="1" >
 					var PLACEHOLDERS = [
 						{
@@ -243,8 +244,6 @@
 
 					templates.append( list );
 				</script>
-				<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 			</section>
 		</section>
 

--- a/docs/sdk/examples/autogrow.html
+++ b/docs/sdk/examples/autogrow.html
@@ -70,6 +70,7 @@ config.autoGrow_bottomSpace = 50;
 				<li><a href="./resize.html">Editor Resizing &ndash; Editor Resizing Customization</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'autogrow',
@@ -80,8 +81,6 @@ config.autoGrow_bottomSpace = 50;
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 		</section>
 	</section>
 

--- a/docs/sdk/examples/autogrow.html
+++ b/docs/sdk/examples/autogrow.html
@@ -76,9 +76,11 @@ config.autoGrow_bottomSpace = 50;
 					autoGrow_minHeight: 200,
 					autoGrow_maxHeight: 600,
 					autoGrow_bottomSpace: 50,
-					removePlugins: 'resize'
+					removePlugins: 'resize',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/autotag.html
+++ b/docs/sdk/examples/autotag.html
@@ -103,7 +103,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'autotag', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/autotag/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
-					plugins: 'textmatch,toolbar,wysiwygarea,basicstyles,link,undo,autotag',
+					plugins: 'textmatch,toolbar,wysiwygarea,basicstyles,link,undo,autotag,pastefromgdocs,pastefromlibreoffice,pastefromword',
 					toolbar: [
 						{ name: 'document', items: [ 'Undo', 'Redo' ] },
 						{ name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline' ] },
@@ -111,6 +111,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					]
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/autotag.html
+++ b/docs/sdk/examples/autotag.html
@@ -99,6 +99,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./mentions.html">Working with Document &ndash; Mentions, Tags and Emoji</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.plugins.addExternal( 'autotag', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/autotag/', 'plugin.js' );
 
@@ -111,8 +112,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					]
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 		</section>
 	</section>
 

--- a/docs/sdk/examples/balloontoolbar.html
+++ b/docs/sdk/examples/balloontoolbar.html
@@ -67,6 +67,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				Please note that this plugin is not compatible with Internet Explorer 8.
 			</p>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script>
 				// Reference plugins loaded from external sources.
 				CKEDITOR.plugins.addExternal( 'openlink', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/openlink/', 'plugin.js' );
@@ -121,7 +122,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.document.getById( 'ie8-warning' ).addClass( 'tip alert' );
 			}
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/balloontoolbar.html
+++ b/docs/sdk/examples/balloontoolbar.html
@@ -111,7 +111,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// resizer (because image size is controlled by widget styles or the image takes maximum
 					// 100% of the editor width).
 					image2_alignClasses: [ 'image-align-left', 'image-align-center', 'image-align-right' ],
-					image2_disableResizer: true
+					image2_disableResizer: true,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -120,6 +121,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.document.getById( 'ie8-warning' ).addClass( 'tip alert' );
 			}
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/basicpreset.html
+++ b/docs/sdk/examples/basicpreset.html
@@ -63,9 +63,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
-				height: 150
+				height: 150,
+				removeButtons: 'PasteFromWord'
 			} );
 		</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		<h2>Related Features</h2>
 		<ul>

--- a/docs/sdk/examples/basicpreset.html
+++ b/docs/sdk/examples/basicpreset.html
@@ -61,13 +61,13 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			&lt;/ul&gt;
 		</textarea>
 
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
 				height: 150,
 				removeButtons: 'PasteFromWord'
 			} );
 		</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		<h2>Related Features</h2>
 		<ul>

--- a/docs/sdk/examples/basicstyles.html
+++ b/docs/sdk/examples/basicstyles.html
@@ -154,6 +154,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./colorbutton.html">Styling and Formatting &ndash; Setting Text and Background Color</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 200,
@@ -177,7 +178,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					coreStyles_italic: { element: 'i', overrides: 'em' }
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/basicstyles.html
+++ b/docs/sdk/examples/basicstyles.html
@@ -159,7 +159,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					height: 200,
 					// By default, some basic text styles buttons are removed in the Standard preset.
 					// The code below resets the default config.removeButtons setting.
-					removeButtons: ''
+					removeButtons: '',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -169,12 +170,14 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// By default, some basic text styles buttons are removed in the Standard preset.
 					// The code below resets the default config.removeButtons setting.
 					removeButtons: '',
+					removeButtons: 'PasteFromWord',
 					// Custom style definition for the Bold feature.
 					coreStyles_bold: { element: 'b', overrides: 'strong' },
 					// Custom style definition for the Italic feature.
 					coreStyles_italic: { element: 'i', overrides: 'em' }
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/bbcode.html
+++ b/docs/sdk/examples/bbcode.html
@@ -74,7 +74,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Remove unused plugins.
 					removePlugins: 'filebrowser,format,horizontalrule,pastetext,pastefromword,scayt,showborders,stylescombo,table,tabletools,tableselection,wsc',
 					// Remove unused buttons.
-					removeButtons: 'Anchor,BGColor,Font,Strike,Subscript,Superscript,JustifyBlock',
+					removeButtons: 'Anchor,BGColor,Font,Strike,Subscript,Superscript,JustifyBlock,PasteFromWord',
 					// Width and height are not supported in the BBCode format, so object resizing is disabled.
 					disableObjectResizing: true,
 					// Define font sizes in percent values.
@@ -91,6 +91,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					]
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/bbcode.html
+++ b/docs/sdk/examples/bbcode.html
@@ -63,6 +63,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			</div>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				// Replace the <textarea id="editor1"> with an CKEditor 4
 				// instance, using the "bbcode" plugin, customizing some of the
@@ -91,7 +92,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					]
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/classic.html
+++ b/docs/sdk/examples/classic.html
@@ -98,6 +98,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				By fine-tuning a stylesheet for CKEditor 4 you can make your content look exactly the same both on
 				the page and inside the editor.
 			</p>
+
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 260,
@@ -116,7 +118,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/classic.html
+++ b/docs/sdk/examples/classic.html
@@ -102,6 +102,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.replace( 'editor1', {
 					height: 260,
 					width: 700,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 			<script data-sample="2">
@@ -111,9 +112,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					contentsCss: [
 						CKEDITOR.basePath + 'contents.css',
 						'assets/css/classic.css'
-					]
+					],
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/codesnippet.html
+++ b/docs/sdk/examples/codesnippet.html
@@ -89,6 +89,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./styles.html#widget-styles">Styling and Formatting &ndash; Applying Styles to Editor Content</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				var config = {
 					extraPlugins: 'codesnippet',
@@ -139,7 +140,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						CKEDITOR.document.getById( 'ie8-warning' ).addClass( 'tip alert' );
 				}() );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/codesnippet.html
+++ b/docs/sdk/examples/codesnippet.html
@@ -93,7 +93,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				var config = {
 					extraPlugins: 'codesnippet',
 					codeSnippet_theme: 'monokai_sublime',
-					height: 356
+					height: 356,
+					removeButtons: 'PasteFromWord'
 				};
 
 				CKEDITOR.replace( 'editor1', config );
@@ -138,6 +139,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						CKEDITOR.document.getById( 'ie8-warning' ).addClass( 'tip alert' );
 				}() );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/colorbutton.html
+++ b/docs/sdk/examples/colorbutton.html
@@ -152,14 +152,16 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 250,
-					extraPlugins: 'colorbutton,colordialog'
+					extraPlugins: 'colorbutton,colordialog',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
 					height: 250,
-					extraPlugins: 'colorbutton'
+					extraPlugins: 'colorbutton',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -168,9 +170,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					height: 250,
 					extraPlugins: 'colorbutton',
 					colorButton_colors: 'CF5D4E,454545,FFF,DDD,CCEAEE,66AB16',
-					colorButton_enableAutomatic: false
+					colorButton_enableAutomatic: false,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/colorbutton.html
+++ b/docs/sdk/examples/colorbutton.html
@@ -149,6 +149,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./format.html">Styling and Formatting &ndash; Applying Block-Level Text Formats</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 250,
@@ -174,7 +175,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/copyformatting.html
+++ b/docs/sdk/examples/copyformatting.html
@@ -245,7 +245,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					height: 255,
 					// Add Copy Formatting and Color Button (Text and Background Color features) plugins.
 					// Color Button is only added just to show that text and background colors can be copied, too.
-					extraPlugins: 'copyformatting,colorbutton'
+					extraPlugins: 'copyformatting,colorbutton',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -254,7 +255,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					height: 450,
 					// Add Copy Formatting and Color Button (Text and Background Color features) plugins.
 					// Color Button is only added just to show that text and background colors can be copied, too.
-					extraPlugins: 'copyformatting,colorbutton'
+					extraPlugins: 'copyformatting,colorbutton',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -265,9 +267,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Only allow Copy Formatting in plain text context.
 					copyFormatting_allowedContexts: [ 'text' ],
 					// Only allow Copy Formatting for bold.
-					copyFormatting_allowRules: 'strong;'
+					copyFormatting_allowRules: 'strong;',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/copyformatting.html
+++ b/docs/sdk/examples/copyformatting.html
@@ -240,6 +240,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./colorbutton.html">Styling and Formatting &ndash; Setting Text and Background Color</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 255,
@@ -271,7 +272,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/devtools.html
+++ b/docs/sdk/examples/devtools.html
@@ -65,9 +65,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 				CKEDITOR.replace( 'editor1', {
 					height: 250,
-					extraPlugins: 'devtools'
+					extraPlugins: 'devtools',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/devtools.html
+++ b/docs/sdk/examples/devtools.html
@@ -57,6 +57,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				Earth.&lt;/p&gt;
 			</textarea>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.config.devtools_styles =
 					'#cke_tooltip { line-height: 20px; font-size: 12px; padding: 5px; border: 2px solid #333; background: #ffffff }' +
@@ -69,7 +70,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/draganddrop.html
+++ b/docs/sdk/examples/draganddrop.html
@@ -300,6 +300,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					}
 				}
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/draganddrop.html
+++ b/docs/sdk/examples/draganddrop.html
@@ -171,6 +171,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./fileupload.html">Inserting Content &ndash; File Upload through Dialogs and Drag&amp;Drop</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				'use strict';
 
@@ -300,7 +301,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					}
 				}
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/easyimage.html
+++ b/docs/sdk/examples/easyimage.html
@@ -208,6 +208,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./image.html">Inserting Images &ndash; Enhanced Image Plugin</a></li>
 				<li><a href="./styles.html#widget-styles">Styling and Formatting &ndash; Applying Styles to Editor Content</a></li>
 			</ul>
+
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script>
 				CKEDITOR.once( 'instanceCreated', function( evt ) {
 					evt.editor.once( 'configLoaded', function( evt ) {
@@ -300,7 +302,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					setupOptimizationsCalculator( evt.editor, '#optimizations' );
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/easyimage.html
+++ b/docs/sdk/examples/easyimage.html
@@ -279,7 +279,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						'EasyImageGradient2',
 						'EasyImageNoGradient',
 						'EasyImageAlt'
-					]
+					],
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -299,6 +300,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					setupOptimizationsCalculator( evt.editor, '#optimizations' );
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/editorplaceholder.html
+++ b/docs/sdk/examples/editorplaceholder.html
@@ -43,9 +43,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'editorplaceholder',
-					editorplaceholder: 'Start typing here...'
+					editorplaceholder: 'Start typing here...',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/editorplaceholder.html
+++ b/docs/sdk/examples/editorplaceholder.html
@@ -47,7 +47,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/editorplaceholder.html
+++ b/docs/sdk/examples/editorplaceholder.html
@@ -40,6 +40,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<textarea cols="10" id="editor1" name="editor1" rows="10" data-sample="1" data-sample-short></textarea>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'editorplaceholder',
@@ -47,7 +48,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/enterkey.html
+++ b/docs/sdk/examples/enterkey.html
@@ -46,7 +46,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					editor = CKEDITOR.replace( 'editor1', {
 						height: 120,
 						enterMode: Number( document.getElementById( 'xEnter' ).value ),
-						shiftEnterMode: Number( document.getElementById( 'xShiftEnter' ).value )
+						shiftEnterMode: Number( document.getElementById( 'xShiftEnter' ).value ),
+						removeButtons: 'PasteFromWord'
 					});
 				}
 
@@ -119,10 +120,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Pressing Enter will create a new &lt;div&gt; element.
 					enterMode: CKEDITOR.ENTER_DIV,
 					// Pressing Shift+Enter will create a new &lt;p&gt; element.
-					shiftEnterMode: CKEDITOR.ENTER_P
+					shiftEnterMode: CKEDITOR.ENTER_P,
+					removeButtons: 'PasteFromWord'
 				} );
 			&lt;/script&gt;
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/enterkey.html
+++ b/docs/sdk/examples/enterkey.html
@@ -34,6 +34,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<nav class="sdk-sidebar">
 		</nav>
 		<section class="sdk-contents">
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script>
 				var editor;
 
@@ -125,7 +126,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				} );
 			&lt;/script&gt;
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -192,13 +192,16 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					{ name: 'align', items: [ 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock' ] },
 					{ name: 'document', items: [ 'PageBreak', 'Source' ] }
 				],
-				bodyClass: 'document-editor'
+				bodyClass: 'document-editor',
+				removeButtons: 'PasteFromWord'
 			} );
 		</script>
 
 		<script>
 			editor.config.exportPdf_appId = 'cke4-demo-docs';
 		</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 	</section>
 </section>
 

--- a/docs/sdk/examples/exporttopdf.html
+++ b/docs/sdk/examples/exporttopdf.html
@@ -156,6 +156,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<li><a href="./acf.html">Content Filtering &ndash; Advanced Content Filter &ndash; Automatic Mode</a></li>
 		</ul>
 
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 		<script>
 			CKEDITOR.plugins.addExternal( 'exportpdf', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/exportpdf/', 'plugin.js' );
 
@@ -200,7 +201,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<script>
 			editor.config.exportPdf_appId = 'cke4-demo-docs';
 		</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 	</section>
 </section>

--- a/docs/sdk/examples/fileupload.html
+++ b/docs/sdk/examples/fileupload.html
@@ -139,7 +139,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					filebrowserBrowseUrl: '/apps/ckfinder/{%CKFINDER_VERSION%}/ckfinder.html',
 					filebrowserImageBrowseUrl: '/apps/ckfinder/{%CKFINDER_VERSION%}/ckfinder.html?type=Images',
 					filebrowserUploadUrl: '/apps/ckfinder/{%CKFINDER_VERSION%}/core/connector/php/connector.php?command=QuickUpload&type=Files',
-					filebrowserImageUploadUrl: '/apps/ckfinder/{%CKFINDER_VERSION%}/core/connector/php/connector.php?command=QuickUpload&type=Images'
+					filebrowserImageUploadUrl: '/apps/ckfinder/{%CKFINDER_VERSION%}/core/connector/php/connector.php?command=QuickUpload&type=Images',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -175,9 +176,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// resizer (because image size is controlled by widget styles or the image takes maximum
 					// 100% of the editor width).
 					image2_alignClasses: [ 'image-align-left', 'image-align-center', 'image-align-right' ],
-					image2_disableResizer: true
+					image2_disableResizer: true,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/fileupload.html
+++ b/docs/sdk/examples/fileupload.html
@@ -131,6 +131,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./draganddrop.html">API Usage &ndash; Drag and Drop Integration</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 300,
@@ -180,7 +181,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/fixedui.html
+++ b/docs/sdk/examples/fixedui.html
@@ -104,6 +104,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./toolbarlocation.html">Editor UI &ndash; Toolbar Location</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
 					height: 250,
@@ -119,7 +120,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/fixedui.html
+++ b/docs/sdk/examples/fixedui.html
@@ -106,7 +106,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
-					height: 250
+					height: 250,
+					removeButtons: 'PasteFromWord'
 				} );
 
 			</script>
@@ -114,9 +115,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="2" >
 				CKEDITOR.replace( 'editor2', {
 					height: 250,
-					extraPlugins: 'divarea'
+					extraPlugins: 'divarea',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/floatingui.html
+++ b/docs/sdk/examples/floatingui.html
@@ -154,6 +154,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./sharedspace.html">Editor UI &ndash; Shared Toolbar and Bottom Bar</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.disableAutoInline = true;
 				CKEDITOR.inline( 'editor1', {
@@ -161,7 +162,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/floatingui.html
+++ b/docs/sdk/examples/floatingui.html
@@ -157,9 +157,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="1">
 				CKEDITOR.disableAutoInline = true;
 				CKEDITOR.inline( 'editor1', {
-					extraPlugins: 'sourcedialog'
+					extraPlugins: 'sourcedialog',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/format.html
+++ b/docs/sdk/examples/format.html
@@ -147,6 +147,7 @@ for each item in sequence S
 				<li><a href="./acf.html">Content Filtering &ndash; Advanced Content Filter &ndash; Automatic Mode</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 280,
@@ -174,7 +175,6 @@ for each item in sequence S
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/format.html
+++ b/docs/sdk/examples/format.html
@@ -151,7 +151,8 @@ for each item in sequence S
 				CKEDITOR.replace( 'editor1', {
 					height: 280,
 					// List of text formats available for this editor instance.
-					format_tags: 'p;h1;h2;h3;h4;h5;h6;pre;address;div'
+					format_tags: 'p;h1;h2;h3;h4;h5;h6;pre;address;div',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -169,9 +170,11 @@ for each item in sequence S
 					// Custom Heading 1 and Formatted format definitions.
 					format_h1: { element: 'h1', attributes: { 'class': 'contentHeader1' } },
 					format_h2: { element: 'h2', attributes: { 'class': 'contentHeader2' } },
-					format_pre: { element: 'pre', attributes: { 'class': 'formattedCode' } }
+					format_pre: { element: 'pre', attributes: { 'class': 'formattedCode' } },
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/fullpage.html
+++ b/docs/sdk/examples/fullpage.html
@@ -96,9 +96,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Disable content filtering because if you use full page mode, you probably
 					// want to  freely enter any HTML content in source mode without any limitations.
 					allowedContent: true,
-					height: 320
+					height: 320,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/fullpage.html
+++ b/docs/sdk/examples/fullpage.html
@@ -89,6 +89,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<a href="./classic.html">classic editor</a>.
 			</div>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
 					fullPage: true,
@@ -100,7 +101,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/fullpreset.html
+++ b/docs/sdk/examples/fullpreset.html
@@ -115,6 +115,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			&lt;p style="text-align:right"&gt;&lt;small&gt;Source: &lt;a href="http://en.wikipedia.org/wiki/Apollo_11"&gt;Wikipedia.org&lt;/a&gt;&lt;/small&gt;&lt;/p&gt;
 		</textarea>
 
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
 				height: 400,
@@ -122,7 +123,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				removeButtons: 'PasteFromWord'
 			} );
 		</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		<h2>Related Features</h2>
 		<ul>

--- a/docs/sdk/examples/fullpreset.html
+++ b/docs/sdk/examples/fullpreset.html
@@ -118,9 +118,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
 				height: 400,
-				baseFloatZIndex: 10005
+				baseFloatZIndex: 10005,
+				removeButtons: 'PasteFromWord'
 			} );
 		</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		<h2>Related Features</h2>
 		<ul>

--- a/docs/sdk/examples/htmlformatting.html
+++ b/docs/sdk/examples/htmlformatting.html
@@ -81,7 +81,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="1">
 				var editor1 = CKEDITOR.replace( 'editor1', {
 					extraAllowedContent : 'div',
-					height: 460
+					height: 460,
+					removeButtons: 'PasteFromWord'
 				} );
 				editor1.on('instanceReady', function() {
 					// Output self-closing tags the HTML4 way, like <br>.
@@ -102,6 +103,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					this.setMode('source');
 				});
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/htmlformatting.html
+++ b/docs/sdk/examples/htmlformatting.html
@@ -78,6 +78,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<div class="tip">
 				<p>Numerous configuration options are available to control the HTML markup (tags, attributes, styles) produced by specific CKEditor 4 features (e.g. <code><a href="https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-coreStyles_bold">config.coreStyles_bold</a></code> for the <strong>Bold</strong> button) or the sort of HTML code that is allowed in the editor (see <a href="./acf.html">Advanced Content Filter</a>). Features mentioned in this sample are strictly associated with generic HTML source code formatting. Going carefully through the list of <a href="https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html">all CKEditor 4 configuration options</a> might help you get familiar with what is possible with CKEditor 4 WYSIWYG editor.</p>
 			</div>
+
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				var editor1 = CKEDITOR.replace( 'editor1', {
 					extraAllowedContent : 'div',
@@ -103,7 +105,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					this.setMode('source');
 				});
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/image.html
+++ b/docs/sdk/examples/image.html
@@ -154,9 +154,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 					height: 560,
 
-					removeDialogTabs: 'image:advanced;link:advanced'
+					removeDialogTabs: 'image:advanced;link:advanced',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/image.html
+++ b/docs/sdk/examples/image.html
@@ -121,6 +121,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./fileupload.html">Inserting Content &ndash; File Upload through Dialogs and Drag&amp;Drop</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1" >
 				CKEDITOR.addCss( '.cke_editable { font-size: 15px; padding: 2em; }' );
 
@@ -158,7 +159,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/image2.html
+++ b/docs/sdk/examples/image2.html
@@ -92,6 +92,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./fileupload.html">Inserting Content &ndash; File Upload through Dialogs and Drag&amp;Drop</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1" >
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'image2,uploadimage',
@@ -125,7 +126,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/image2.html
+++ b/docs/sdk/examples/image2.html
@@ -121,9 +121,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Simplify the Image and Link dialog windows. The "Advanced" tab is not needed in most cases.
 					removeDialogTabs: 'image:advanced;link:advanced',
 
-					height: 450
+					height: 450,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/inline.html
+++ b/docs/sdk/examples/inline.html
@@ -409,6 +409,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						'forms,iframe,image,newpage,removeformat,' +
 						'smiley,specialchar,stylescombo,templates';
 
+				editor.config.removeButtons = 'PasteFromWord';
+
 				// Rearrange the toolbar layout.
 				editor.config.toolbarGroups = [
 					{ name: 'editing', groups: [ 'basicstyles', 'links' ] },
@@ -420,6 +422,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		}
 	} );
 </script>
+<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 </body>
 </html>

--- a/docs/sdk/examples/inline.html
+++ b/docs/sdk/examples/inline.html
@@ -299,6 +299,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<li><a href="./saveajax.html">Saving Data &ndash; CKEditor 4 in Ajax Applications</a></li>
 		</ul>
 
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 		<script>
 			// Sample: Inline Editing Enabled by Code
 			( function() {
@@ -361,7 +362,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				onClick( reset, resetContent );
 			} )();
 		</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 	</section>
 </section>
 

--- a/docs/sdk/examples/inline.html
+++ b/docs/sdk/examples/inline.html
@@ -314,6 +314,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 							extraAllowedContent: 'a(documentation);abbr[title];code',
 							removePlugins: 'stylescombo',
 							extraPlugins: 'sourcedialog',
+							removeButtons: 'PasteFromWord',
 							startupFocus: true
 						} );
 					}
@@ -360,6 +361,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				onClick( reset, resetContent );
 			} )();
 		</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 	</section>
 </section>
 
@@ -377,6 +379,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			extraAllowedContent: 'a(documentation);abbr[title];code',
 			removePlugins: 'stylescombo',
 			extraPlugins: 'sourcedialog',
+			removeButtons: 'PasteFromWord',
 			// Show toolbar on startup (optional).
 			startupFocus: true
 		} );
@@ -422,7 +425,5 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		}
 	} );
 </script>
-<script src="assets/pastefromoffice/pastefromoffice.js"></script>
-
 </body>
 </html>

--- a/docs/sdk/examples/language.html
+++ b/docs/sdk/examples/language.html
@@ -113,7 +113,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					contentsLangDirection: 'rtl',
 					height: 270,
 					scayt_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
-					scayt_sLang: 'auto'
+					scayt_sLang: 'auto',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -124,9 +125,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					language_list: [ 'ar:Arabic:rtl', 'fr:French',  'he:Hebrew:rtl', 'es:Spanish' ],
 					height: 270,
 					scayt_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
-					scayt_sLang: 'auto'
+					scayt_sLang: 'auto',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/language.html
+++ b/docs/sdk/examples/language.html
@@ -106,6 +106,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./uilanguages.html">User Interface &ndash; Setting Editor UI Language</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'bidi',
@@ -129,7 +130,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/magicline.html
+++ b/docs/sdk/examples/magicline.html
@@ -103,6 +103,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				&lt;/div&gt;
 			</textarea>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: '500',
@@ -115,7 +116,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/magicline.html
+++ b/docs/sdk/examples/magicline.html
@@ -111,9 +111,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Magic Line does not require any additional ACF settings.
 					// We set config.extraAllowedContent because HTML code in this sample contains
 					// a <div> element with custom styles that we would like to allow.
-					extraAllowedContent: 'div{border,background,text-align}'
+					extraAllowedContent: 'div{border,background,text-align}',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/mathjax.html
+++ b/docs/sdk/examples/mathjax.html
@@ -53,6 +53,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./styles.html#widget-styles">Styling and Formatting &ndash; Applying Styles to Editor Content</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'mathjax',
@@ -65,7 +66,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					document.getElementById( 'ie8-warning' ).className = 'tip alert';
 				}
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<p id="ie8-warning">
 				Please note that this plugin is not compatible with Internet Explorer 8.

--- a/docs/sdk/examples/mathjax.html
+++ b/docs/sdk/examples/mathjax.html
@@ -57,13 +57,15 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'mathjax',
 					mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
-					height: 320
+					height: 320,
+					removeButtons: 'PasteFromWord'
 				} );
 
 				if ( CKEDITOR.env.ie && CKEDITOR.env.version == 8 ) {
 					document.getElementById( 'ie8-warning' ).className = 'tip alert';
 				}
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<p id="ie8-warning">
 				Please note that this plugin is not compatible with Internet Explorer 8.

--- a/docs/sdk/examples/mathtype.html
+++ b/docs/sdk/examples/mathtype.html
@@ -69,6 +69,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./mathjax.html">Inserting Content &ndash; Creating Mathematical Formulas with MathJax</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				( function() {
 					var mathElements = [
@@ -129,7 +130,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					} );
 				}() );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/mathtype.html
+++ b/docs/sdk/examples/mathtype.html
@@ -124,10 +124,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						removePlugins: 'uploadimage,uploadwidget,uploadfile,filetools,filebrowser',
 						height: 320,
 						// Update the ACF configuration with MathML syntax.
-						extraAllowedContent: mathElements.join( ' ' ) + '(*)[*]{*};img[data-mathml,data-custom-editor,role](Wirisformula)'
+						extraAllowedContent: mathElements.join( ' ' ) + '(*)[*]{*};img[data-mathml,data-custom-editor,role](Wirisformula)',
+						removeButtons: 'PasteFromWord'
 					} );
 				}() );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/mediaembed.html
+++ b/docs/sdk/examples/mediaembed.html
@@ -127,6 +127,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./styles.html#widget-styles">Styling and Formatting &ndash; Applying Styles to Editor Content</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'embed,autoembed,image2',
@@ -148,7 +149,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/mediaembed.html
+++ b/docs/sdk/examples/mediaembed.html
@@ -144,9 +144,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// resizer (because image size is controlled by widget styles or the image takes maximum
 					// 100% of the editor width).
 					image2_alignClasses: [ 'image-align-left', 'image-align-center', 'image-align-right' ],
-					image2_disableResizer: true
+					image2_disableResizer: true,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/mentions.html
+++ b/docs/sdk/examples/mentions.html
@@ -310,8 +310,10 @@
 							outputTemplate: '<a href="https://example.com/social?tag={name}">{name}</a><span>&nbsp;</span>',
 							minChars: 1
 						}
-					]
+					],
+					removeButtons: 'PasteFromWord'
 				} );
+
 
 				function dataFeed( opts, callback ) {
 					var matchProperty = 'username',
@@ -336,6 +338,8 @@
 						} );
 					} );
 				</script>
+				<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 			</section>
 		</section>
 

--- a/docs/sdk/examples/mentions.html
+++ b/docs/sdk/examples/mentions.html
@@ -281,7 +281,7 @@
 					];
 
 				CKEDITOR.replace( 'editor1', {
-					plugins: 'mentions,emoji,basicstyles,undo,link,wysiwygarea,toolbar',
+					plugins: 'mentions,emoji,basicstyles,undo,link,wysiwygarea,toolbar, pastefromgdocs, pastefromlibreoffice, pastefromword',
 					contentsCss: [
 						CKEDITOR.basePath + 'contents.css',
 						'assets/mentions/contents.css'

--- a/docs/sdk/examples/mentions.html
+++ b/docs/sdk/examples/mentions.html
@@ -314,7 +314,6 @@
 					removeButtons: 'PasteFromWord'
 				} );
 
-
 				function dataFeed( opts, callback ) {
 					var matchProperty = 'username',
 						data = users.filter( function( item ) {

--- a/docs/sdk/examples/mentions.html
+++ b/docs/sdk/examples/mentions.html
@@ -191,6 +191,7 @@
 					<li><a href="./autocomplete.html">Working with Document &ndash; Autocomplete</a></li>
 				</ul>
 
+				<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 				<script data-sample="1" >
 					var users = [
 						{ id: 1, avatar: 'm_1', fullname: 'Charles Flores', username: 'cflores' },
@@ -337,7 +338,6 @@
 						} );
 					} );
 				</script>
-				<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			</section>
 		</section>

--- a/docs/sdk/examples/placeholder.html
+++ b/docs/sdk/examples/placeholder.html
@@ -57,6 +57,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./styles.html#widget-styles">Styling and Formatting &ndash; Applying Styles to Editor Content</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'placeholder',
@@ -64,7 +65,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/placeholder.html
+++ b/docs/sdk/examples/placeholder.html
@@ -60,9 +60,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'placeholder',
-					height: 220
+					height: 220,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/readonly.html
+++ b/docs/sdk/examples/readonly.html
@@ -32,6 +32,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<nav class="sdk-sidebar">
 		</nav>
 		<section class="sdk-contents">
+
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				var editor;
 
@@ -99,7 +101,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				in the &lt;a href=&quot;http://en.wikipedia.org/wiki/Pacific_Ocean&quot; title=&quot;Pacific Ocean&quot;&gt;Pacific Ocean&lt;/a&gt; on July 24.&lt;/p&gt; &lt;hr/&gt; &lt;p style=&quot;text-align:
 				right;&quot;&gt;&lt;small&gt;Source: &lt;a href=&quot;http://en.wikipedia.org/wiki/Apollo_11&quot;&gt;Wikipedia.org&lt;/a&gt;&lt;/small&gt;&lt;/p&gt;
 			</textarea>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/readonly.html
+++ b/docs/sdk/examples/readonly.html
@@ -34,28 +34,29 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<section class="sdk-contents">
 			<script data-sample="1">
 				var editor;
-		
+
 				// The instanceReady event is fired when an instance of CKEditor 4 has finished
 				// its initialization.
 				CKEDITOR.on( 'instanceReady', function ( ev ) {
 					editor = ev.editor;
-		
+
 					// Show this "on" button.
 					document.getElementById( 'readOnlyOn' ).style.display = '';
-		
+
 					// Event fired when the readOnly property changes.
 					editor.on( 'readOnly', function () {
 						document.getElementById( 'readOnlyOn' ).style.display = this.readOnly ? 'none' : '';
 						document.getElementById( 'readOnlyOff' ).style.display = this.readOnly ? '' : 'none';
 					} );
 				} );
-		
+
 				function toggleReadOnly( isReadOnly ) {
 					// Change the read-only state of the editor.
 					// https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-setReadOnly
 					editor.setReadOnly( isReadOnly );
 				}
 			</script>
+
 			<h1>Read-Only Mode <a class="documentation" href="https://ckeditor.com/docs/ckeditor4/latest/features/readonly.html">Documentation</a></h1>
 
 			<p>
@@ -98,6 +99,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				in the &lt;a href=&quot;http://en.wikipedia.org/wiki/Pacific_Ocean&quot; title=&quot;Pacific Ocean&quot;&gt;Pacific Ocean&lt;/a&gt; on July 24.&lt;/p&gt; &lt;hr/&gt; &lt;p style=&quot;text-align:
 				right;&quot;&gt;&lt;small&gt;Source: &lt;a href=&quot;http://en.wikipedia.org/wiki/Apollo_11&quot;&gt;Wikipedia.org&lt;/a&gt;&lt;/small&gt;&lt;/p&gt;
 			</textarea>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/removeformat.html
+++ b/docs/sdk/examples/removeformat.html
@@ -124,9 +124,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						{ name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },
 						{ name: 'paragraph',   groups: [ 'list', 'indent', 'blocks', 'align', 'bidi' ] },
 						{ name: 'styles' }
-					]
+					],
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/removeformat.html
+++ b/docs/sdk/examples/removeformat.html
@@ -99,6 +99,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./colorbutton.html">Styling and Formatting &ndash; Setting Text and Background Color</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 250,
@@ -128,7 +129,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/resize.html
+++ b/docs/sdk/examples/resize.html
@@ -116,6 +116,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./autogrow.html">Editor Resizing &ndash; Automatic Editor Height Adjustment to Content</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					width: 600,
@@ -127,7 +128,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/resize.html
+++ b/docs/sdk/examples/resize.html
@@ -123,9 +123,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					resize_dir: 'both',
 					resize_minWidth: 200,
 					resize_minHeight: 300,
-					resize_maxWidth: 800
+					resize_maxWidth: 800,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/saveajax.html
+++ b/docs/sdk/examples/saveajax.html
@@ -33,6 +33,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<nav class="sdk-sidebar">
 		</nav>
 		<section class="sdk-contents">
+
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				var editor1, html = '';
 
@@ -147,7 +149,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					} );
 				})();
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/saveajax.html
+++ b/docs/sdk/examples/saveajax.html
@@ -35,29 +35,29 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<section class="sdk-contents">
 			<script data-sample="1">
 				var editor1, html = '';
-		
+
 				function createEditor() {
 					if ( editor1 )
 						return;
-		
+
 					// Create a new editor instance inside the <div id="editor"> element,
 					// setting its value to html.
 					var config = {};
 					editor1 = CKEDITOR.appendTo( 'editor1', config, html );
-		
+
 					// Update button states.
 					document.getElementById( 'remove' ).style.display = '';
 					document.getElementById( 'create' ).style.display = 'none';
 				}
-		
+
 				function removeEditor() {
 					if ( !editor1 )
 						return;
-		
+
 					// Retrieve the editor content. In an Ajax application this data would be
 					// sent to the server or used in any other way.
 					html = editor1.getData();
-		
+
 					// Update <div> with "Edited Content".
 					document.getElementById( 'editorcontent1' ).innerHTML = html;
 					// Show <div> with "Edited Content".
@@ -65,7 +65,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Update button states.
 					document.getElementById( 'remove' ).style.display = 'none';
 					document.getElementById( 'create' ).style.display = '';
-		
+
 					// Destroy the editor.
 					editor1.destroy();
 					editor1 = null;
@@ -135,7 +135,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				(function () {
 					var changesCount = 0;
 					var editor2 = CKEDITOR.replace( 'editor2', {
-						removePlugins: 'sourcearea'
+						removePlugins: 'sourcearea',
+						removeButtons: 'PasteFromWord'
 
 					} );
 					editor2.on( 'change', function ( ev ) {
@@ -146,6 +147,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					} );
 				})();
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/savetextarea.html
+++ b/docs/sdk/examples/savetextarea.html
@@ -111,6 +111,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./saveajax.html">Saving Data &ndash; CKEditor 4 in Ajax Applications</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					removeButtons: 'PasteFromWord'
@@ -121,7 +122,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/savetextarea.html
+++ b/docs/sdk/examples/savetextarea.html
@@ -112,11 +112,17 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			</ul>
 
 			<script data-sample="1">
-				CKEDITOR.replace( 'editor1' );
+				CKEDITOR.replace( 'editor1', {
+					removeButtons: 'PasteFromWord'
+				} );
 			</script>
 			<script data-sample="2">
-				CKEDITOR.inline( 'editor2' );
+				CKEDITOR.inline( 'editor2', {
+					removeButtons: 'PasteFromWord'
+				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/sharedspace.html
+++ b/docs/sdk/examples/sharedspace.html
@@ -164,6 +164,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./toolbar.html">Toolbar &ndash; Custom Editor Toolbar</a></li>
 				<li><a href="./toolbarlocation.html">Toolbar &ndash; Toolbar Location Adjustment</a></li>
 			</ul>
+
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'sharedspace',
@@ -202,7 +204,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/sharedspace.html
+++ b/docs/sdk/examples/sharedspace.html
@@ -172,7 +172,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					sharedSpaces: {
 						top: 'top',
 						bottom: 'bottom'
-					}
+					},
+					removeButtons: 'PasteFromWord'
 				} );
 
 				CKEDITOR.replace( 'editor2', {
@@ -197,9 +198,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					sharedSpaces: {
 						top: 'top2',
 						bottom: 'bottom2'
-					}
+					},
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/simplebox.html
+++ b/docs/sdk/examples/simplebox.html
@@ -96,6 +96,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./styles.html#widget-styles">Styling and Formatting &ndash; Applying Styles to Editor Content</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.plugins.addExternal( 'simplebox', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/simplebox/', 'plugin.js' );
 
@@ -116,7 +117,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/simplebox.html
+++ b/docs/sdk/examples/simplebox.html
@@ -112,9 +112,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					],
 
 					// Set height to make more content visible.
-					height: 500
+					height: 500,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/size.html
+++ b/docs/sdk/examples/size.html
@@ -91,9 +91,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					width: '70%',
-					height: 500
+					height: 500,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/size.html
+++ b/docs/sdk/examples/size.html
@@ -88,6 +88,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./autogrow.html">Editor Resizing &ndash; Automatic Editor Height Adjustment to Content</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					width: '70%',
@@ -95,7 +96,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/sourcearea.html
+++ b/docs/sdk/examples/sourcearea.html
@@ -110,6 +110,7 @@ config.extraPlugins = &amp;#39;sourcedialog&amp;#39;;
 config.removePlugins = &amp;#39;sourcearea&amp;#39;;&lt;/pre&gt;
 			</textarea>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				// We need to turn off the automatic editor creation first.
 				CKEDITOR.disableAutoInline = true;
@@ -138,7 +139,6 @@ config.removePlugins = &amp;#39;sourcearea&amp;#39;;&lt;/pre&gt;
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/sourcearea.html
+++ b/docs/sdk/examples/sourcearea.html
@@ -123,7 +123,8 @@ config.removePlugins = &amp;#39;sourcearea&amp;#39;;&lt;/pre&gt;
 
 				CKEDITOR.inline( 'editor2', {
 					extraPlugins: 'sourcedialog',
-					removePlugins: 'sourcearea'
+					removePlugins: 'sourcearea',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -133,9 +134,11 @@ config.removePlugins = &amp;#39;sourcearea&amp;#39;;&lt;/pre&gt;
 
 				CKEDITOR.replace( 'editor3', {
 					extraPlugins: 'sourcedialog',
-					removePlugins: 'sourcearea'
+					removePlugins: 'sourcearea',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<h2>Related Features</h2>
 

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -127,6 +127,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				&lt;p&gt;&lt;small&gt;Source: &lt;a href=&quot;http://en.wikipedia.org/wiki/Apollo_11&quot;&gt;Wikipedia.org&lt;/a&gt;&lt;/small&gt;&lt;/p&gt;
 			</textarea>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					height: 250,
@@ -184,7 +185,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/spellchecker.html
+++ b/docs/sdk/examples/spellchecker.html
@@ -135,7 +135,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Limit the number of suggestions available in the context menu.
 					scayt_maxSuggestions: 3,
 					scayt_customerId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
-					scayt_sLang: 'en_US'
+					scayt_sLang: 'en_US',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -145,7 +146,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					// Remove the SpellCheckAsYouType (SCAYT) plugin.
 					removePlugins: 'scayt',
 					// Add the WebSpellChecker plugin.
-					extraPlugins: 'wsc'
+					extraPlugins: 'wsc',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -168,7 +170,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						instanceReady: function( evt ) {
 							evt.editor.container.findOne( 'iframe' ).addClass( 'cke_wproofreader' );
 						}
-					}
+					},
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
@@ -177,9 +180,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					height: 250,
 					// Remove the SpellCheckAsYouType (SCAYT) plugin.
 					removePlugins: 'scayt',
-					disableNativeSpellChecker: false
+					disableNativeSpellChecker: false,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 		</section>
 	</section>
 

--- a/docs/sdk/examples/spreadsheets.html
+++ b/docs/sdk/examples/spreadsheets.html
@@ -516,6 +516,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<li><a href="./table.html">Inserting Content &ndash; Table Support with Column Resizing</a></li>
 		</ul>
 
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 		<script>
 			// Umberto SDK does not copy the `<head>` content, so the crawler option will not be visible in the output file.
 			// That's why it is added manually in the `<script>` tag.
@@ -654,7 +655,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 			} );
 		</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 	</section>
 </section>

--- a/docs/sdk/examples/spreadsheets.html
+++ b/docs/sdk/examples/spreadsheets.html
@@ -594,7 +594,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						{ name: 'styles', items: [ 'Font', 'FontSize' ] },
 						{ name: 'document', items: [ 'Print' ] },
 						{ name: 'tools', items: [ 'Maximize' ] }
-					]
+					],
+					removeButtons: 'PasteFromWord'
 			} );
 		</script>
 
@@ -649,9 +650,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						{ name: 'styles', items: [ 'Font', 'FontSize' ] },
 						{ name: 'document', items: [ 'Print' ] },
 						{ name: 'tools', items: [ 'Maximize' ] }
-					]
+					],
+					removeButtons: 'PasteFromWord'
 			} );
 		</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
+
 	</section>
 </section>
 

--- a/docs/sdk/examples/standardpreset.html
+++ b/docs/sdk/examples/standardpreset.html
@@ -117,9 +117,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
 				height: 400,
-				baseFloatZIndex: 10005
+				baseFloatZIndex: 10005,
+				removeButtons: 'PasteFromWord'
 			} );
 		</script>
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		<h2>Related Features</h2>
 		<ul>

--- a/docs/sdk/examples/standardpreset.html
+++ b/docs/sdk/examples/standardpreset.html
@@ -114,6 +114,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			&lt;p&gt;&lt;small&gt;Source: &lt;a href="http://en.wikipedia.org/wiki/Apollo_11"&gt;Wikipedia.org&lt;/a&gt;&lt;/small&gt;&lt;/p&gt;
 		</textarea>
 
+		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 		<script data-sample="1">
 			CKEDITOR.replace( 'editor1', {
 				height: 400,
@@ -121,7 +122,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				removeButtons: 'PasteFromWord'
 			} );
 		</script>
-		<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		<h2>Related Features</h2>
 		<ul>

--- a/docs/sdk/examples/styles.html
+++ b/docs/sdk/examples/styles.html
@@ -174,14 +174,15 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'widget',
-					height: 300
+					height: 300,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
 
 			<script data-sample="2">
 				CKEDITOR.replace( 'editor2', {
 					extraPlugins: 'autoembed,embedsemantic,image2,mathjax,codesnippet,font',
-					removeButtons: 'Font',
+					removeButtons: 'Font, PasteFromWord',
 					height: 300,
 					mathJaxLib: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML'
 				} );
@@ -198,9 +199,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					],
 
 					// Do not load the default Styles configuration.
-					stylesSet: []
+					stylesSet: [],
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/styles.html
+++ b/docs/sdk/examples/styles.html
@@ -171,6 +171,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./colorbutton.html">Styling and Formatting &ndash; Setting Text and Background Color</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'widget',
@@ -203,7 +204,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/tabindex.html
+++ b/docs/sdk/examples/tabindex.html
@@ -59,13 +59,13 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<input type="checkbox" checked>Sample checkbox
 			</p>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script>
 				CKEDITOR.replace( 'editor1', {
 					height: 150,
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<p>
 				Additionally, you can influence the place that CKEditor 4 will assume in the web page <kbd>Tab</kbd> order. Refer to the <a href="https://ckeditor.com/docs/ckeditor4/latest/features/tabindex.html">Page Navigation Using the

--- a/docs/sdk/examples/tabindex.html
+++ b/docs/sdk/examples/tabindex.html
@@ -61,9 +61,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script>
 				CKEDITOR.replace( 'editor1', {
-					height: 150
+					height: 150,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<p>
 				Additionally, you can influence the place that CKEditor 4 will assume in the web page <kbd>Tab</kbd> order. Refer to the <a href="https://ckeditor.com/docs/ckeditor4/latest/features/tabindex.html">Page Navigation Using the

--- a/docs/sdk/examples/table.html
+++ b/docs/sdk/examples/table.html
@@ -178,9 +178,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'colordialog,tableresize',
-					height: 470
+					height: 470,
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/table.html
+++ b/docs/sdk/examples/table.html
@@ -175,6 +175,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./spreadsheets.html">Inserting Content &ndash; Creating Data Grids with Spreadsheet Plugin</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'colordialog,tableresize',
@@ -182,7 +183,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/timestamp.html
+++ b/docs/sdk/examples/timestamp.html
@@ -63,6 +63,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./api.html">API Usage &ndash; Using CKEditor 4 API</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.plugins.addExternal( 'timestamp', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/timestamp/', 'plugin.js' );
 
@@ -71,7 +72,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/timestamp.html
+++ b/docs/sdk/examples/timestamp.html
@@ -67,9 +67,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				CKEDITOR.plugins.addExternal( 'timestamp', '../../../ckeditor4/{%CKEDITOR_VERSION%}/{%CKEDITOR_EXAMPLES_SLUG%}/assets/plugins/timestamp/', 'plugin.js' );
 
 				CKEDITOR.replace( 'editor1', {
-					extraPlugins: 'timestamp'
+					extraPlugins: 'timestamp',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/toolbar.html
+++ b/docs/sdk/examples/toolbar.html
@@ -142,6 +142,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./fullpreset.html">Editor Presets &ndash; Full Preset</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					// Define the toolbar groups as it is a more accessible solution.
@@ -158,7 +159,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'Underline,Strike,Subscript,Superscript,Anchor,Styles,Specialchar,PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/toolbar.html
+++ b/docs/sdk/examples/toolbar.html
@@ -155,9 +155,10 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 						{"name":"about","groups":["about"]}
 					],
 					// Remove the redundant buttons from toolbar groups defined above.
-					removeButtons: 'Underline,Strike,Subscript,Superscript,Anchor,Styles,Specialchar'
+					removeButtons: 'Underline,Strike,Subscript,Superscript,Anchor,Styles,Specialchar,PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/toolbarlocation.html
+++ b/docs/sdk/examples/toolbarlocation.html
@@ -83,9 +83,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					toolbarLocation: 'bottom',
 					// Remove some plugins that would conflict with the bottom
 					// toolbar position.
-					removePlugins: 'elementspath,resize'
+					removePlugins: 'elementspath,resize',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/toolbarlocation.html
+++ b/docs/sdk/examples/toolbarlocation.html
@@ -78,6 +78,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./sharedspace.html">Editor UI &ndash; Shared Toolbar and Bottom Bar</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					toolbarLocation: 'bottom',
@@ -87,7 +88,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/uicolor.html
+++ b/docs/sdk/examples/uicolor.html
@@ -81,13 +81,13 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./uicolorpicker.html">Utilities &ndash; UI Color Picker</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					uiColor: '#CCEAEE',
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/uicolor.html
+++ b/docs/sdk/examples/uicolor.html
@@ -83,9 +83,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					uiColor: '#CCEAEE'
+					uiColor: '#CCEAEE',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/uicolorpicker.html
+++ b/docs/sdk/examples/uicolorpicker.html
@@ -90,13 +90,13 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				<li><a href="./uicolor.html">User Interface &ndash; Setting Editor UI Color</a></li>
 			</ul>
 
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
 					extraPlugins: 'uicolor',
 					removeButtons: 'PasteFromWord'
 				} );
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/uicolorpicker.html
+++ b/docs/sdk/examples/uicolorpicker.html
@@ -92,9 +92,11 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 			<script data-sample="1">
 				CKEDITOR.replace( 'editor1', {
-					extraPlugins: 'uicolor'
+					extraPlugins: 'uicolor',
+					removeButtons: 'PasteFromWord'
 				} );
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/uilanguages.html
+++ b/docs/sdk/examples/uilanguages.html
@@ -64,6 +64,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<h2>Available Localizations</h2>
 			<p>
 				The following <strong><span id="count"> </span> language versions</strong> are available in CKEditor 4:<br>
+
+				<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 				<script>
 
 					document.write( '<select disabled="disabled" id="languages" onchange="createEditor( this.value );">' );
@@ -142,7 +144,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				createEditor( '' );
 
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<script type="template" data-sample="1">
 			&lt;script&gt;

--- a/docs/sdk/examples/uilanguages.html
+++ b/docs/sdk/examples/uilanguages.html
@@ -133,7 +133,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 								languages.value = this.langCode;
 								languages.disabled = false;
 							}
-						}
+						},
+						removeButtons: 'PasteFromWord'
 					} );
 				}
 
@@ -145,10 +146,12 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<script type="template" data-sample="1">
 			&lt;script&gt;
 				CKEDITOR.replace( 'editor1', {
-					language: 'es'
+					language: 'es',
+					removeButtons: 'PasteFromWord'
 				} );
 			&lt;/script&gt;
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>

--- a/docs/sdk/examples/uilanguages.html
+++ b/docs/sdk/examples/uilanguages.html
@@ -142,6 +142,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				createEditor( '' );
 
 			</script>
+			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 			<script type="template" data-sample="1">
 			&lt;script&gt;
@@ -151,7 +152,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				} );
 			&lt;/script&gt;
 			</script>
-			<script src="assets/pastefromoffice/pastefromoffice.js"></script>
 
 		</section>
 	</section>


### PR DESCRIPTION
I've added notification when a user tries to paste content from external sources (Word, Excel, GDocs, LibreOffice) into the examples. 
The code detects the source from which the content is being pasted and, based on that, displays appropriate links to the examples. 

For some reasons full detection doesn't working in Safari and IE.
Safari detects pasted content from Word and Google Docs.
IE can only detect pasted content from Word.