### PR TITLE
Remove flash plugin mentions

### DIFF
--- a/docs/features/mathtype/README.md
+++ b/docs/features/mathtype/README.md
@@ -137,7 +137,7 @@ If you visit a page using MathType with your mobile device, the handwriting inte
 
 ## Input and Output
 
-MathType is based upon standards like MathML for internal representation and the PNG image format for displaying formulas. It can also handle other formats like LaTeX, SVG and EPS.
+MathType is based upon standards like MathML for internal representation and the PNG image format for displaying formulas. It can also handle other formats like LaTeX, Flash, SVG and EPS.
 
 Equations and chemical formulas are displayed in the editor as {@link features/image/README images}, having all their advantages, i.e. you can **treat the entire equation as one entity** and select, delete, or move it with drag and drop in the editor content area as one unit.
 

--- a/docs/features/mathtype/README.md
+++ b/docs/features/mathtype/README.md
@@ -137,7 +137,7 @@ If you visit a page using MathType with your mobile device, the handwriting inte
 
 ## Input and Output
 
-MathType is based upon standards like MathML for internal representation and the PNG image format for displaying formulas. It can also handle other formats like LaTeX, Flash, SVG and EPS.
+MathType is based upon standards like MathML for internal representation and the PNG image format for displaying formulas. It can also handle other formats like LaTeX, SVG and EPS.
 
 Equations and chemical formulas are displayed in the editor as {@link features/image/README images}, having all their advantages, i.e. you can **treat the entire equation as one entity** and select, delete, or move it with drag and drop in the editor content area as one unit.
 

--- a/docs/guide/dev/integration/file_browse_upload/README.md
+++ b/docs/guide/dev/integration/file_browse_upload/README.md
@@ -16,7 +16,7 @@ For licensing, see LICENSE.md.
 	CKEditor 4 can be easily integrated with an external file manager (file browser/uploader) thanks to the <a href="https://ckeditor.com/cke4/addon/filebrowser">File Browser</a> plugin which by default is included in every preset.
 </info-box>
 
-Once properly set up, all file manager features will automatically become available. This includes the **Upload** tab `(1)` in the **Link**, **Image**, and **Flash Properties** dialog windows as well as the **Browse Server** button `(2)`.
+Once properly set up, all file manager features will automatically become available. This includes the **Upload** tab `(1)` in the **Link**, **Image**, and **Browse Server** button `(2)`.
 
 {@img assets/img/image_dialog_browser_upload.png 500 File browser features available for images in CKEditor 4 WYSIWYG editor}
 
@@ -28,7 +28,7 @@ In order to integrate CKEditor 4 WYSIWYG editor with a file manager, you need to
 
  * The {@linkapi CKEDITOR.config#filebrowserBrowseUrl `config.filebrowserBrowseUrl`} setting contains the location of an external file browser that should be launched when the **Browse Server** button is pressed.
 
- * The {@linkapi CKEDITOR.config#filebrowserUploadUrl `config.filebrowserUploadUrl`} setting contains the location of a script that handles file uploads. If set, the **Upload** tab will appear in some dialog windows &mdash; the ones where such functionality is available, i.e. **Link**, **Image** and **Flash Properties**.
+ * The {@linkapi CKEDITOR.config#filebrowserUploadUrl `config.filebrowserUploadUrl`} setting contains the location of a script that handles file uploads. If set, the **Upload** tab will appear in some dialog windows &mdash; the ones where such functionality is available, i.e. **Link**, **Image**.
 
 The sample below shows basic configuration code that can be used to create a CKEditor 4 instance with the file manager configured.
 

--- a/docs/sdk/examples/fullpreset.html
+++ b/docs/sdk/examples/fullpreset.html
@@ -51,7 +51,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			This heavier package contains plenty of plugins suitable for various different needs. Apart from the features included in the
 			Standard
 			package, it
-			also has document tools (new page, page break, preview, print, save, content templates), find and replace, form tools, <a href="./copyformatting.html">copy formatting</a>, text alignment, <a href="./language.html">text direction and language</a>, font family and size, <a href="./colorbutton.html">text and background color</a>, inserting Flash objects, smileys and iframe elements. Select all and show blocks features provide some additional tools for working with the document.
+			also has document tools (new page, page break, preview, print, save, content templates), find and replace, form tools, <a href="./copyformatting.html">copy formatting</a>, text alignment, <a href="./language.html">text direction and language</a>, font family and size, <a href="./colorbutton.html">text and background color</a>, inserting smileys and iframe elements. Select all and show blocks features provide some additional tools for working with the document.
 		</p>
 
 		<textarea cols="80" id="editor1" name="editor1" rows="10" data-sample="1" data-sample-short>

--- a/docs/sdk/examples/inline.html
+++ b/docs/sdk/examples/inline.html
@@ -405,7 +405,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			editor.on( 'configLoaded', function () {
 
 				// Remove redundant plugins to make the editor simpler.
-				editor.config.removePlugins = 'colorbutton,find,flash,font,' +
+				editor.config.removePlugins = 'colorbutton,find,font,' +
 						'forms,iframe,image,newpage,removeformat,' +
 						'smiley,specialchar,stylescombo,templates';
 


### PR DESCRIPTION
I've removed `flash` mentions from docs due to removing it from `ckeditor4` repo since `v4.17.0`. 

We can wait with this, untill: ckeditor/ckeditor4#4867