### PR TITLE
Add Error Code Reference to flash plugin

### DIFF
--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -104,9 +104,10 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 
 ## editor-plugin-deprecated
 
-* Location: `plugins/flash/plugin.js`
-* Description: Flash plugin has been removed from CKEditor since 4.17.0 and is no longer available.
-* Additional data: None.
+* Location: `core/editor.js`
+* Description: The plugin has been deprecated and should no longer be used.
+* Additional data:
+	* `plugin`: The name of the plugin that has been deprecated.
 
 ## embed-no-provider-url
 * Location: `plugins/embed/plugin.js`

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -102,6 +102,12 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 	* `plugin`: The name of the plugin that cannot be removed.
 	* `requiredBy`: The name of the plugin whose requirements block the removal.
 
+## editor-plugin-deprecated
+
+* Location: `plugins/flash/plugin.js`
+* Description: Flash plugin has been removed from CKEditor since 4.17.0 and is no longer available.
+* Additional data: None.
+
 ## embed-no-provider-url
 * Location: `plugins/embed/plugin.js`
 * Description: No {@linkapi CKEDITOR.config#embed_provider embed provider URL} configured. Since CKEditor 4.7.0 this value is empty by default.


### PR DESCRIPTION
Regarding to removing `flash` plugin from our ecosystem I've added `Error Code Reference` to flash plugin.

Closes [#4877](https://github.com/ckeditor/ckeditor4/issues/4877).