### PR TITLE
Add info about the new `clipboard-image-handling-disabled` error

### DIFF
--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -24,6 +24,14 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 * Description: Incorrect {@linkapi CKEDITOR.config#autoEmbed_widget} value. No widget definition found.
 * Additional data: None.
 
+## clipboard-image-handling-disabled
+
+* Location: `plugins/uploadimage/plugin.js`
+* Description: The default image handling logic from the Clipboard plugin is interferring with another plugin handling uploading images. Therefore, the image handling logic from the Clipboard plugin was disabled. To prevent the automatic disabling of the Clipboard's image handling logic, manually set the {@linkapi CKEDITOR.config#clipboard_handleImages} config variable to `false`.
+* Additional data:
+	* `editor`: The name of the editor in which the image handling was disabled.
+	* `plugin`: The name of the plugin that disabled the image handling.
+
 ## cloudservices-no-token
 
 * Location: `plugins/cloudservices/plugin.js`

--- a/docs/guide/dev/deep_dive/errors/README.md
+++ b/docs/guide/dev/deep_dive/errors/README.md
@@ -27,7 +27,7 @@ This article contains the list of CKEditor 4 error codes and their explanations.
 ## clipboard-image-handling-disabled
 
 * Location: `plugins/uploadimage/plugin.js`
-* Description: The default image handling logic from the Clipboard plugin is interferring with another plugin handling uploading images. Therefore, the image handling logic from the Clipboard plugin was disabled. To prevent the automatic disabling of the Clipboard's image handling logic, manually set the {@linkapi CKEDITOR.config#clipboard_handleImages} config variable to `false`.
+* Description: [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin {@linkapi CKEDITOR.config#clipboard_handleImages} option logic is interfering with another plugin, therefore, that option was force-disabled. To prevent the automatic disabling of the Clipboard's image handling logic, manually set the {@linkapi CKEDITOR.config#clipboard_handleImages} config variable to `false`.
 * Additional data:
 	* `editor`: The name of the editor in which the image handling was disabled.
 	* `plugin`: The name of the plugin that disabled the image handling.


### PR DESCRIPTION
Followup to ckeditor/ckeditor4#5364.

I've added a description of the new `clipboard-image-handling-disabled` error alongside a short note how to disable it.