### PR TITLE
Docs: adding EOL info to CKE4 docs.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,14 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 
 # CKEditor 4 Documentation
 
+<info-box hint>
+	<strong>CKEditor 4 reaches its End of Life (EOL) in June 2023</strong>. From then on, it will receive no more updates, new features, bug fixes, and most importantly, security patches.
+	
+	Please refer to the [Migration from CKEditor 4](https://ckeditor.com/docs/ckeditor5/latest/updating/ckeditor4/migration-from-ckeditor-4.html) guide to learn what steps you should take to switch to our new CKEditor 5.
+
+	If you have an active CKEditor 4 subscription and need help, you can contact [our support team](https://ckeditor.com/contact/). If you are not ready to migrate yet, for a limited time we are offering a paid <strong>Extended Support Model</strong> that will protect you against security vulnerabilities and/or breaking third-party API changes.
+</info-box>
+
 <dl>
 <dt>{@link guide/index CKEditor 4 Developer's Guide}</dt><dd>Learn how to install, integrate and configure CKEditor 4 WYSIWYG editor. More complex aspects, like creating plugins, widgets, and skins are explained here, too.</dd>
 <dt>{@link features/index CKEditor 4 Features}</dt><dd>An overview of the WYSIWYG editor features, covering both end-user functionality and integration aspects.</dd>

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 <info-box hint>
 	<strong>CKEditor 4 reaches its End of Life (EOL) in June 2023</strong>. From then on, it will receive no more updates, new features, bug fixes, and most importantly, security patches.
 	
-	Please refer to the [Migration from CKEditor 4](https://ckeditor.com/docs/ckeditor5/latest/updating/ckeditor4/migration-from-ckeditor-4.html) guide to learn what steps you should take to switch to our new CKEditor 5.
+	Please refer to the [Migration from CKEditor 4](https://ckeditor.com/docs/ckeditor5/latest/updating/ckeditor4/migration-from-ckeditor-4.html) guide to learn what steps you should take to switch to CKEditor 5.
 
 	If you have an active CKEditor 4 subscription and need help, you can contact [our support team](https://ckeditor.com/contact/). If you are not ready to migrate yet, for a limited time we are offering a paid <strong>Extended Support Model</strong> that will protect you against security vulnerabilities and/or breaking third-party API changes.
 </info-box>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 
 # CKEditor 4 Documentation
 
-<info-box hint>
+<info-box warning>
 	<strong>CKEditor 4 reaches its End of Life (EOL) in June 2023</strong>. From then on, it will receive no more updates, new features, bug fixes, and most importantly, security patches.
 	
 	Please refer to the [Migration from CKEditor 4](https://ckeditor.com/docs/ckeditor5/latest/updating/ckeditor4/migration-from-ckeditor-4.html) guide to learn what steps you should take to switch to CKEditor 5.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 	
 	Please refer to the [Migration from CKEditor 4](https://ckeditor.com/docs/ckeditor5/latest/updating/ckeditor4/migration-from-ckeditor-4.html) guide to learn what steps you should take to switch to CKEditor 5.
 
-	If you have an active CKEditor 4 subscription and need help, you can contact [our support team](https://ckeditor.com/contact/). If you are not ready to migrate yet, for a limited time we are offering a paid <strong>Extended Support Model</strong> that will protect you against security vulnerabilities and/or breaking third-party API changes.
+	If you have an active CKEditor 4 subscription and need help, you can contact [our support team](https://ckeditor.com/contact/). If you are not ready to migrate yet, for a limited time we are offering a paid [Extended Support Model](https://ckeditor.com/ckeditor-4-support/) that will protect you against security vulnerabilities and/or breaking third-party API changes.
 </info-box>
 
 <dl>


### PR DESCRIPTION
Docs: Adding End of Life information and migration guide link of CKEditor 4 main docs page. Closes https://github.com/cksource/ckeditor5-internal/issues/3310