### PR TITLE
Docs: links fix.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -16,4 +16,4 @@ default-expanded: CKEDITOR
 
 ## Contribute
 
-CKEditor is an Open Source project and your contribution is most welcome. Feel free to {@link guide/dev/issues_readme/README report bugs} or improve the code on [GitHub](https://github.com/ckeditor/ckeditor4). Since CKEditor is localized, you can also help [to translate it](https://www.transifex.com/ckeditor/ckeditor/). You do not need to be a programmer to contribute to the project!
+CKEditor is an Open Source project and your contribution is most welcome. Feel free to {@link guide/dev/issues_readme/README report bugs} or improve the code on [GitHub](https://github.com/ckeditor/ckeditor4). Since CKEditor is localized, you can also help [to translate it](https://explore.transifex.com/ckeditor/ckeditor/). You do not need to be a programmer to contribute to the project!

--- a/docs/features/uilanguage/README.md
+++ b/docs/features/uilanguage/README.md
@@ -15,7 +15,7 @@ For licensing, see LICENSE.md.
 CKEditor 4 is translated into 70 languages and by default, it is displayed in the user's language (as set in the browser or operating system settings). If the matching language version is not available, the editor user interface will be displayed in the default language version (most commonly: English).
 
 <info-box hint="">
-    Please note that CKEditor 4 localizations are mostly provided by our awesome community through the <a href="https://www.transifex.com/projects/p/ckeditor/">CKEditor UI Translation Center</a>, so if you would like to help with translating CKEditor 4 into your native language or correct an existing localization, do not hesitate to join us!
+    Please note that CKEditor 4 localizations are mostly provided by our awesome community through the <a href="https://explore.transifex.com/ckeditor/ckeditor/">CKEditor UI Translation Center</a>, so if you would like to help with translating CKEditor 4 into your native language or correct an existing localization, do not hesitate to join us!
 </info-box>
 
 ## Setting the Default Language

--- a/docs/guide/dev/contributing/README.md
+++ b/docs/guide/dev/contributing/README.md
@@ -20,7 +20,7 @@ This section explains how you can contribute to CKEditor 4 development. CKEditor
 
 3. Create your own plugins or skins and submit them to [CKEditor Add-Ons Repository](https://ckeditor.com/cke4/addons/plugins/all).
 
-4. Help [localize CKEditor](http://docs.cksource.com/CKEditor_3.x/Developers_Guide/Localization) into your native language and update existing localizations by joining us at the [CKEditor UI Translation Center](https://www.transifex.com/ckeditor/ckeditor/).
+4. Help [localize CKEditor](http://docs.cksource.com/CKEditor_3.x/Developers_Guide/Localization) into your native language and update existing localizations by joining us at the [CKEditor UI Translation Center](https://explore.transifex.com/ckeditor/ckeditor/).
 
 5. Join StackOverflow and share your knowledge with [fellow CKEditor users and developers](http://stackoverflow.com/questions/tagged/ckeditor).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,4 +34,4 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 
 ## Contribute
 
-CKEditor is an Open Source project and your contribution is most welcome. Feel free to {@link guide/dev/issues_readme/README report bugs} or improve the code on [GitHub](https://github.com/ckeditor/ckeditor4). Since CKEditor is localized, you can also help [to translate it](https://www.transifex.com/ckeditor/ckeditor/). You do not need to be a programmer to contribute to the project!
+CKEditor is an Open Source project and your contribution is most welcome. Feel free to {@link guide/dev/issues_readme/README report bugs} or improve the code on [GitHub](https://github.com/ckeditor/ckeditor4). Since CKEditor is localized, you can also help [to translate it](https://explore.transifex.com/ckeditor/ckeditor/). You do not need to be a programmer to contribute to the project!

--- a/docs/sdk/examples/mathtype.html
+++ b/docs/sdk/examples/mathtype.html
@@ -45,7 +45,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 			<h2>Using MathType</h2>
 
 			<p>
-				The MathType window is split into two main areas: a <a href="https://docs.wiris.com/en/mathtype/mathtype_web/toolbar">tabbed toolbar</a> that contains a large number of icons that are useful for creating math equations and chemical formulas, and an editing area where you can see your current formula, the location of the cursor, and the text currently selected (if any).
+				The MathType window is split into two main areas: a tabbed toolbar that contains a large number of icons that are useful for creating math equations and chemical formulas, and an editing area where you can see your current formula, the location of the cursor, and the text currently selected (if any).
 			</p>
 
 			<p>


### PR DESCRIPTION
Fixing 404 links in the documentation.

Closes: https://github.com/ckeditor/ckeditor5-commercial/issues/9038